### PR TITLE
Add group-filter to abakusleader-view

### DIFF
--- a/frontend/src/routes/AdminPageAbakusLeaderView/GroupStatistics.tsx
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/GroupStatistics.tsx
@@ -4,17 +4,22 @@ import StatisticsName from "./StatisticsName";
 import StatisticsWrapper from "./StatisticsWrapper";
 import StatisticsGroupLogo from "./StatisticsGroupLogo";
 import { Application } from "src/types";
+import styled from "styled-components";
 
 interface GroupStatisticsProps {
   applications: Application[];
   groupName: string;
   groupLogo: string;
+  selectedGroups: string[];
+  setSelectedGroups: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const GroupStatistics: React.FC<GroupStatisticsProps> = ({
   applications,
   groupName,
   groupLogo,
+  selectedGroups,
+  setSelectedGroups,
 }) => {
   const calculateNumGroupApplications = (groupName: string) => {
     let sum = 0;
@@ -30,14 +35,46 @@ const GroupStatistics: React.FC<GroupStatisticsProps> = ({
     return sum;
   };
 
+  const toggleSelectedGroup = () =>
+    setSelectedGroups(
+      selectedGroups.includes(groupName)
+        ? selectedGroups.filter((selectedGroup) => selectedGroup !== groupName)
+        : [...selectedGroups, groupName]
+    );
+
   const count = calculateNumGroupApplications(groupName);
   return (
-    <StatisticsWrapper smallerMargin>
+    <GroupStatisticsWrapper
+      smallerMargin
+      selected={
+        selectedGroups.includes(groupName) || selectedGroups.length === 0
+      }
+      onClick={toggleSelectedGroup}
+    >
       <StatisticsGroupLogo src={groupLogo} />
       <StatisticsName capitalize>{groupName}</StatisticsName>
       {count} stk
-    </StatisticsWrapper>
+    </GroupStatisticsWrapper>
   );
 };
 
 export default GroupStatistics;
+
+interface GroupStatisticsWrapperProps {
+  selected: boolean;
+}
+
+const GroupStatisticsWrapper = styled(
+  StatisticsWrapper
+)<GroupStatisticsWrapperProps>`
+  margin: 0.25em;
+  padding: 0.5em 0.5em;
+  opacity: ${(props) => (props.selected ? 1 : 0.4)};
+  transition: ease-in-out 0.15s opacity;
+  border-radius: 2px;
+
+  &:hover {
+    background-color: var(--lego-gray-light);
+    cursor: pointer;
+  }
+`;

--- a/frontend/src/routes/AdminPageAbakusLeaderView/index.tsx
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/index.tsx
@@ -31,6 +31,10 @@ const AdminPageAbakusLeaderView = () => {
   const [sortedApplications, setSortedApplications] = useState<Application[]>(
     []
   );
+  const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
+  const [filteredApplications, setFilteredApplications] = useState<
+    Application[]
+  >([]);
   const [csvData, setCsvData] = useState<CompleteCsvData[]>([]);
 
   const csvHeaders = [
@@ -68,9 +72,21 @@ const AdminPageAbakusLeaderView = () => {
   }, [applications]);
 
   useEffect(() => {
+    setFilteredApplications(
+      sortedApplications.filter(
+        (application) =>
+          selectedGroups.length === 0 ||
+          application.group_applications.find((groupApplication) =>
+            selectedGroups.includes(groupApplication.group.name)
+          )
+      )
+    );
+  }, [sortedApplications, selectedGroups]);
+
+  useEffect(() => {
     // Push all the individual applications into csvData with the right format
     const updatedCsvData: CompleteCsvData[] = [];
-    sortedApplications.forEach((application) => {
+    filteredApplications.forEach((application) => {
       application.group_applications.forEach((groupApplication) => {
         updatedCsvData.push({
           name: application.user.full_name,
@@ -90,7 +106,7 @@ const AdminPageAbakusLeaderView = () => {
       });
     });
     setCsvData(updatedCsvData);
-  }, [sortedApplications]);
+  }, [filteredApplications]);
 
   const numApplicants = sortedApplications.length;
 
@@ -155,6 +171,8 @@ const AdminPageAbakusLeaderView = () => {
                     applications={sortedApplications}
                     groupName={group.name}
                     groupLogo={group.logo}
+                    selectedGroups={selectedGroups}
+                    setSelectedGroups={setSelectedGroups}
                   />
                 ))}
             </Statistics>
@@ -167,7 +185,7 @@ const AdminPageAbakusLeaderView = () => {
           >
             Eksporter som csv
           </CSVExport>
-          <AdmissionsContainer applications={sortedApplications} />
+          <AdmissionsContainer applications={filteredApplications} />
         </Wrapper>
       </PageWrapper>
     );


### PR DESCRIPTION
Fixes ABA-187

## Changes
* The total stats of the groups (as seen in the preview below) are clickable
* A click toggles whether the applications to that group should be displayed or not
    * This also includes when the user downloads the CSV
* If no groups are selected all applications are shown
* This change does not affect what group-applications are displayed on a pr user basis - so the admin will still be able to see every application each user submitted

## Preview of visual changes
Before:
![image](https://user-images.githubusercontent.com/13599770/207464974-374a3dc9-a27f-4dab-8b3d-1d926ac6a9f0.png)
After:
![image](https://user-images.githubusercontent.com/13599770/207464415-97ac564a-1da4-4441-991e-fb69ed580365.png)
Opacity alternative;
![image](https://user-images.githubusercontent.com/13599770/208266330-72dfa59f-24dd-4065-b927-bf8e21229946.png)

Actions from left to right:
1. Selected and not hovered
2. Selected and hovered
3. Not selected and hovered
4. Not selected and not hovered (identical to how every group was displayed previously)