### PR TITLE
Add workflow to automerge devDependencies <=minor

### DIFF
--- a/.github/workflows/automerge-dev-deps.yml
+++ b/.github/workflows/automerge-dev-deps.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot dependency <=minor PRs
+        if: ${{!contains(steps.metadata.outputs.dependency-types, 'production') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This workflow *should* enable auto-merge for all Dependabot PRs that are devDependencies (currently only frontend deps as our backend deps are a mess), with level minor or patch.

This repo is not tested well enough to automerge all deps, but dev dependencies should only be used for the stuff that is already tested - so I'd say these deps should be ready to merge if the build process passes.

I didn't find a neat way to test this without deploying it, so I hope it works 🤞  doesn't differ that much from githubs own examples https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions

Resolves ABA-269