### PR TITLE
Fix error in automerge script

### DIFF
--- a/.github/workflows/automerge-dev-deps.yml
+++ b/.github/workflows/automerge-dev-deps.yml
@@ -15,8 +15,8 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot dependency <=minor PRs
-        if: ${{!contains(steps.metadata.outputs.dependency-types, 'production') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')}}
+      - name: Enable auto-merge for Dependabot dev-dependency PRs with version <=minor
+        if: ${{steps.metadata.outputs.dependency-type == 'direct:development' && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')}}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
The script previously automerged both production and development dependencies, this should fix it so that only dev dependencies are automerged.