### PR TITLE
Add new frontend to administrate admissions

### DIFF
--- a/frontend/src/components/LegoButton/index.tsx
+++ b/frontend/src/components/LegoButton/index.tsx
@@ -17,6 +17,7 @@ interface LegoButtonProps extends PropsWithChildren {
   iconPrefix?: string;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   size?: "small" | "normal";
+  type?: "button" | "submit" | "reset";
 }
 
 const LegoButton: React.FC<LegoButtonProps> = ({
@@ -29,6 +30,7 @@ const LegoButton: React.FC<LegoButtonProps> = ({
   iconPrefix = "md",
   onClick,
   size = "normal",
+  type = "button",
 }) => {
   if (to) {
     return (
@@ -36,6 +38,7 @@ const LegoButton: React.FC<LegoButtonProps> = ({
         to={to}
         buttonStyle={buttonStyle}
         onClick={onClick}
+        size={size}
         disabled={disabled}
       >
         <Text buttonStyle={buttonStyle}>{children}</Text>
@@ -64,6 +67,7 @@ const LegoButton: React.FC<LegoButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       size={size}
+      type={type}
     >
       <Text buttonStyle={buttonStyle}>{children}</Text>
       {icon && <Icon name={icon} prefix={iconPrefix} />}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -16,6 +16,7 @@ import "src/styles/globals.css";
 import config from "src/utils/config";
 import djangoData from "src/utils/djangoData";
 import "@babel/polyfill";
+import ManageAdmissions from "src/routes/ManageAdmissions";
 
 Sentry.init({
   dsn: config.SENTRY_DSN,
@@ -54,6 +55,7 @@ const App: React.FC<PropsWithChildren> = ({ children }) => {
 const AppRoutes = () =>
   useRoutes([
     { path: "/", element: <LandingPage /> },
+    { path: "/admin/*", element: <ManageAdmissions /> },
     { path: ":admissionId/*", element: <ApplicationPortal /> },
     { path: "*", element: <NotFoundPage /> },
   ]);

--- a/frontend/src/query/hooks.ts
+++ b/frontend/src/query/hooks.ts
@@ -10,8 +10,10 @@ export const useAdmissions = () => {
   return useQuery<Admission[], QueryError>(["/admission/"]);
 };
 
-export const useAdmission = (admissionId: string) => {
-  return useQuery<Admission, QueryError>([`/admission/${admissionId}/`]);
+export const useAdmission = (admissionId: string, enabled = true) => {
+  return useQuery<Admission, QueryError>([`/admission/${admissionId}/`], {
+    enabled,
+  });
 };
 
 export const useApplications = (admissionId: string) => {

--- a/frontend/src/routes/AdminPage/index.tsx
+++ b/frontend/src/routes/AdminPage/index.tsx
@@ -7,7 +7,7 @@ import { media } from "src/styles/mediaQueries";
 import UserApplication from "src/containers/UserApplication";
 import LoadingBall from "src/components/LoadingBall";
 import EditGroupForm from "./form";
-import { replaceQuotationMarks } from "src/utils/replaceQuotationMarks";
+import { replaceQuotationMarks } from "src/utils/methods";
 import {
   Wrapper,
   LinkLink,

--- a/frontend/src/routes/AdminPageAbakusLeaderView/index.tsx
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/index.tsx
@@ -12,7 +12,7 @@ import Statistics from "./Statistics";
 import GroupStatistics from "./GroupStatistics";
 import StatisticsName from "./StatisticsName";
 import StatisticsWrapper from "./StatisticsWrapper";
-import { replaceQuotationMarks } from "src/utils/replaceQuotationMarks";
+import { replaceQuotationMarks } from "src/utils/methods";
 import { useAdmission, useApplications } from "src/query/hooks";
 import { useParams } from "react-router-dom";
 

--- a/frontend/src/routes/LandingPage/LandingPageSkeleton.tsx
+++ b/frontend/src/routes/LandingPage/LandingPageSkeleton.tsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import { media } from "src/styles/mediaQueries";
 
 import AbakusLogo from "src/components/AbakusLogo";
+import djangoData from "src/utils/djangoData";
+import LegoButton from "src/components/LegoButton";
 
 const LandingPageSkeleton: React.FC<PropsWithChildren> = ({ children }) => {
   return (
@@ -12,6 +14,18 @@ const LandingPageSkeleton: React.FC<PropsWithChildren> = ({ children }) => {
       </BrandContainer>
       <Title>Opptak</Title>
       {children}
+      {djangoData.user.is_superuser && (
+        <LegoButtonWrapper>
+          <LegoButton
+            to={`/admin/`}
+            icon="arrow-forward"
+            iconPrefix="ios"
+            buttonStyle="secondary"
+          >
+            Administrer opptak
+          </LegoButton>
+        </LegoButtonWrapper>
+      )}
     </Container>
   );
 };
@@ -52,4 +66,8 @@ const Title = styled.h1`
   ${media.handheld`
     font-size: 1.3rem;
   `};
+`;
+
+const LegoButtonWrapper = styled.div`
+  margin-top: 3em;
 `;

--- a/frontend/src/routes/ManageAdmissions/CreateAdmission.tsx
+++ b/frontend/src/routes/ManageAdmissions/CreateAdmission.tsx
@@ -1,0 +1,204 @@
+import { useFormik } from "formik";
+import { DateTime } from "luxon";
+import React, { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import LegoButton from "src/components/LegoButton";
+import { useAdmission } from "src/query/hooks";
+import { Group } from "src/types";
+import { toggleFromArray } from "src/utils/methods";
+import styled from "styled-components";
+import GroupSelector from "./components/GroupSelector";
+
+const formatDateString = (dateString?: string) =>
+  formatDate(DateTime.fromISO(dateString ?? ""));
+const formatCurrentDate = () => formatDate(DateTime.now());
+const formatDate = (date: DateTime) => date.toFormat("yyyy-MM-d'T'hh:mm:ss");
+
+const CreateAdmission: React.FC = () => {
+  const { admissionId } = useParams();
+  const { data: admission, isLoading } = useAdmission(
+    admissionId ?? "",
+    admissionId !== undefined
+  );
+
+  const isNew = !admissionId;
+
+  const formik = useFormik({
+    initialValues: {
+      title: "",
+      slug: "",
+      openTime: formatCurrentDate(),
+      deadline: formatCurrentDate(),
+      closeTime: formatCurrentDate(),
+      adminGroups: [],
+      groups: [],
+    },
+    onSubmit: (values) => {
+      console.log(JSON.stringify(values, null, 2));
+    },
+  });
+
+  useEffect(() => {
+    if (admission) {
+      formik.setValues({
+        title: admission.title,
+        slug: "",
+        openTime: formatDateString(admission.open_from),
+        deadline: formatDateString(admission.public_deadline),
+        closeTime: formatDateString(admission.application_deadline),
+        adminGroups: [],
+        groups: [],
+      });
+    }
+  }, [admission]);
+
+  if (isLoading && admissionId !== undefined) {
+    return <></>;
+  }
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <Title>
+        {isNew ? "Opprett nytt opptak" : "Redigerer: " + admission?.title}
+      </Title>
+      <FormGroup>
+        <InputWrapper>
+          <InputTitle>Tittel</InputTitle>
+          <InputDescription>
+            Navnet som vises for brukere når de søker på opptaket
+          </InputDescription>
+          <Input
+            name="title"
+            value={formik.values.title}
+            onChange={formik.handleChange}
+          />
+        </InputWrapper>
+        <InputWrapper>
+          <InputTitle>Slug</InputTitle>
+          <InputDescription>
+            Opptaket vil ligge under opptak.abakus.no/[slug]/
+          </InputDescription>
+          <Input
+            name="slug"
+            value={formik.values.slug}
+            onChange={formik.handleChange}
+            placeholder="f. eks. komiteer/revy/backup"
+            disabled={!isNew}
+          />
+        </InputWrapper>
+      </FormGroup>
+      <FormGroup>
+        <InputWrapper>
+          <InputTitle>Opptaket åpner</InputTitle>
+          <InputDescription>
+            Fra dette tidspunktet er det mulig å legge inn søknader
+          </InputDescription>
+          <Input
+            name="openTime"
+            type="datetime-local"
+            value={formik.values.openTime}
+            onChange={formik.handleChange}
+          />
+        </InputWrapper>
+        <InputWrapper>
+          <InputTitle>Søknadsfrist</InputTitle>
+          <InputDescription>
+            Etter dette er ikke søkere garantert å bli sett, men de kan fortsatt
+            søke og redigere søknaden sin.
+          </InputDescription>
+          <Input
+            name="deadline"
+            type="datetime-local"
+            value={formik.values.deadline}
+            onChange={formik.handleChange}
+          />
+        </InputWrapper>
+        <InputWrapper>
+          <InputTitle>Opptaket stenger</InputTitle>
+          <InputDescription>
+            Etter dette tidspunktet er det ikke mulig å legge inn søknader
+          </InputDescription>
+          <Input
+            name="closeTime"
+            type="datetime-local"
+            value={formik.values.closeTime}
+            onChange={formik.handleChange}
+          />
+        </InputWrapper>
+      </FormGroup>
+      <FormGroup>
+        <InputWrapper>
+          <InputTitle>Admin-grupper</InputTitle>
+          <InputDescription>
+            Lederne av disse gruppene får tilgang til å se samtlige søkere.
+          </InputDescription>
+          <GroupSelector
+            value={formik.values.adminGroups}
+            toggleGroup={(value) => {
+              formik.setFieldValue(
+                "adminGroups",
+                toggleFromArray<Group>(formik.values.adminGroups, value)
+              );
+            }}
+          />
+        </InputWrapper>
+      </FormGroup>
+      <FormGroup>
+        <InputWrapper>
+          <InputTitle>Grupper som har opptak</InputTitle>
+          <InputDescription>
+            Ledere og opptaksansvarlige i disse gruppene kan se søknadene til
+            sin respektive gruppe.
+          </InputDescription>
+          <GroupSelector
+            value={formik.values.groups}
+            toggleGroup={(value) => {
+              formik.setFieldValue(
+                "groups",
+                toggleFromArray<Group>(formik.values.groups, value)
+              );
+            }}
+          />
+        </InputWrapper>
+      </FormGroup>
+      <LegoButton type="submit">Opprett opptak</LegoButton>
+    </form>
+  );
+};
+
+export default CreateAdmission;
+
+const Title = styled.h2`
+  margin-top: 0;
+`;
+
+const FormGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 30px;
+  margin-bottom: 2rem;
+`;
+
+const InputWrapper = styled.div`
+  flex-basis: 550px;
+`;
+
+const InputTitle = styled.p`
+  font-size: 22px;
+  line-height: 1.2;
+  margin: 0;
+`;
+
+const InputDescription = styled.span`
+  display: block;
+`;
+
+const Input = styled.input`
+  font-size: 16px;
+  max-width: 100%;
+  width: 300px;
+  padding: 5px;
+  border-radius: 3px;
+  border: 1px solid #d6d6d6;
+`;

--- a/frontend/src/routes/ManageAdmissions/components/GroupSelector.tsx
+++ b/frontend/src/routes/ManageAdmissions/components/GroupSelector.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from "react";
+import { Group } from "src/types";
+import { callApiFromQuery } from "src/utils/callApi";
+import styled from "styled-components";
+
+interface GroupSelectorProps {
+  value: Group[];
+  toggleGroup: (group: Group) => void;
+}
+
+const GroupSelector: React.FC<GroupSelectorProps> = ({
+  value: selectedGroups,
+  toggleGroup,
+}) => {
+  const [groups, setGroups] = useState<Group[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const res = await callApiFromQuery("/group/");
+      setGroups(res);
+    })();
+  }, []);
+
+  const toggleSelectedGroup = (groupId: number) => {
+    const group = groups.find((group) => group.pk === groupId);
+    if (group) toggleGroup(group);
+  };
+
+  return (
+    <>
+      <Select
+        placeholder="Skriv inn navnet på en gruppe"
+        onChange={(e) => toggleSelectedGroup(Number(e.target.value))}
+      >
+        <option>Legg til gruppe</option>
+        {groups
+          .filter((group) => !selectedGroups.includes(group))
+          .map((groupSuggestion) => (
+            <option key={groupSuggestion.pk} value={groupSuggestion.pk}>
+              {groupSuggestion.name}
+            </option>
+          ))}
+      </Select>
+      <SelectedGroupWrapper>
+        {selectedGroups.map((group) => (
+          <SelectedGroup
+            key={"selected" + group.pk}
+            onClick={() => toggleSelectedGroup(group.pk)}
+            alt={group.name}
+            title={group.name}
+            src={group.logo}
+          />
+        ))}
+      </SelectedGroupWrapper>
+    </>
+  );
+};
+
+export default GroupSelector;
+
+const Select = styled.select`
+  font-size: 16px;
+  max-width: 100%;
+  width: 300px;
+  padding: 5px;
+  border-radius: 3px;
+  border: 1px solid #d6d6d6;
+`;
+
+const SelectedGroupWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+`;
+
+const SelectedGroup = styled.img`
+  display: block;
+  flex-basis: 50px;
+  height: 50px;
+  border-radius: 25px;
+  cursor: pointer;
+  margin-right: 5px;
+`;

--- a/frontend/src/routes/ManageAdmissions/components/NavBar.tsx
+++ b/frontend/src/routes/ManageAdmissions/components/NavBar.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import LegoButton from "src/components/LegoButton";
+import { Admission } from "src/types";
+import styled from "styled-components";
+
+interface Props {
+  admissions?: Admission[];
+}
+
+const NavBar: React.FC<Props> = ({ admissions }) => {
+  return (
+    <Wrapper>
+      <NavHeader>Opptak</NavHeader>
+      {admissions?.map((admission) => (
+        <NavLink key={admission.pk} to={"/admin/" + admission.pk}>
+          {admission.title}
+        </NavLink>
+      ))}
+      <CreateNewWrapper>
+        <LegoButton buttonStyle="primary" to="/admin/" icon="add" size="small">
+          Lag nytt
+        </LegoButton>
+      </CreateNewWrapper>
+    </Wrapper>
+  );
+};
+
+export default NavBar;
+
+const Wrapper = styled.div`
+  padding: 0 1rem;
+`;
+
+const NavHeader = styled.h3`
+  margin: 0;
+`;
+
+const NavLink = styled(Link)`
+  display: inline-block;
+  padding: 0.2rem 0;
+  font-weight: 500;
+  vertical-align: center;
+`;
+
+const CreateNewWrapper = styled.div`
+  margin-top: 1rem;
+`;

--- a/frontend/src/routes/ManageAdmissions/index.tsx
+++ b/frontend/src/routes/ManageAdmissions/index.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import styled from "styled-components";
+import { Route, Routes } from "react-router-dom";
+import { useAdmissions } from "src/query/hooks";
+import { media } from "src/styles/mediaQueries";
+import LoadingBall from "src/components/LoadingBall";
+import NavBar from "./components/NavBar";
+import CreateAdmission from "./CreateAdmission";
+
+const ManageAdmissions: React.FC = () => {
+  const { data, isFetching, error } = useAdmissions();
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  } else if (isFetching) {
+    return <LoadingBall />;
+  } else {
+    return (
+      <PageWrapper>
+        <Header>
+          <h1>Administrer opptak</h1>
+        </Header>
+        <Wrapper>
+          <LeftSide>
+            <NavBar admissions={data} />
+          </LeftSide>
+          <RightSide>
+            <Routes>
+              <Route path="" element={<CreateAdmission key="newAdmission" />} />
+              <Route
+                path=":admissionId"
+                element={<CreateAdmission key="editAdmission" />}
+              />
+            </Routes>
+          </RightSide>
+        </Wrapper>
+      </PageWrapper>
+    );
+  }
+};
+
+export default ManageAdmissions;
+
+/** Styles **/
+
+export const PageWrapper = styled.div`
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding-bottom: 2em;
+`;
+
+const Header = styled.div`
+  width: 100%;
+  background: var(--lego-background);
+  ${media.handheld`
+    margin: 0 1em 0 1em;
+    font-size: 2.5rem;
+  `};
+`;
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+`;
+
+const LeftSide = styled.div`
+  flex-basis: 250px;
+  flex-shrink: 0;
+`;
+
+const RightSide = styled.div`
+  flex-grow: 1;
+`;

--- a/frontend/src/utils/methods.ts
+++ b/frontend/src/utils/methods.ts
@@ -1,0 +1,25 @@
+/**
+ *  Removes an item if it matches the predicate, remove it if it doesn't.
+ *
+ * @param array     The original array
+ * @param item      The item to either remove or add to the array
+ * @param predicate Optional predicate to decide when to remove or add
+ * @returns The new, updated, array
+ */
+export const toggleFromArray: <T>(
+  array: T[],
+  item: T,
+  predicate?: (value: T, index: number, array: T[]) => boolean
+) => void = (array, item, predicate = (value) => value === item) =>
+  array.includes(item)
+    ? array.filter((value, index, array) => !predicate(value, index, array))
+    : [...array, item];
+
+/**
+ * Replace double quotation marks with single quotation marks
+ *
+ * @param text The string to be replaced
+ * @returns A string where " is replaced by '
+ */
+export const replaceQuotationMarks = (text: string) =>
+  text.replaceAll('"', "'");

--- a/frontend/src/utils/replaceQuotationMarks.ts
+++ b/frontend/src/utils/replaceQuotationMarks.ts
@@ -1,2 +1,0 @@
-export const replaceQuotationMarks = (text: string) =>
-  text.replaceAll('"', "'");


### PR DESCRIPTION
## Summarized changes
* Add manage admissions-button from start page for superusers
* Create frontend-view to edit and create admissions
* Add missing size prop to navigate-links in LegoButton component

NB: This currently has no functionality, but I wanted to get my designs merged before I start working on the API-changes.  
(No persistent functionality - it already fetches the values that exist from the backend, the group-selectors work and the results of the form are currently just being console logged)

## Preview
Start page
![image](https://user-images.githubusercontent.com/13599770/220452924-d2af7c9e-2def-43e1-bdf7-19d8f92f5041.png)

Edit page (the same design and components for create and edit)

![image](https://user-images.githubusercontent.com/13599770/220453578-bf5d4f6c-5b01-4418-bd6b-7d4f914e9cde.png)