### PR TITLE
Cleanup console errors and nav errors

### DIFF
--- a/frontend/src/components/LegoButton/index.tsx
+++ b/frontend/src/components/LegoButton/index.tsx
@@ -36,12 +36,12 @@ const LegoButton: React.FC<LegoButtonProps> = ({
     return (
       <ILegoRouterLink
         to={to}
-        buttonStyle={buttonStyle}
+        $buttonStyle={buttonStyle}
         onClick={onClick}
-        size={size}
+        $size={size}
         disabled={disabled}
       >
-        <Text buttonStyle={buttonStyle}>{children}</Text>
+        <Text $buttonStyle={buttonStyle}>{children}</Text>
         {icon && <Icon name={icon} prefix={iconPrefix} />}
       </ILegoRouterLink>
     );
@@ -51,11 +51,11 @@ const LegoButton: React.FC<LegoButtonProps> = ({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        buttonStyle={buttonStyle}
+        $buttonStyle={buttonStyle}
         onClick={onClick}
         disabled={disabled}
       >
-        <Text buttonStyle={buttonStyle}>{children}</Text>
+        <Text $buttonStyle={buttonStyle}>{children}</Text>
         {icon && <Icon name={icon} prefix={iconPrefix} />}
       </ILegoLink>
     );
@@ -63,13 +63,13 @@ const LegoButton: React.FC<LegoButtonProps> = ({
 
   return (
     <ILegoButton
-      buttonStyle={buttonStyle}
+      $buttonStyle={buttonStyle}
       onClick={onClick}
       disabled={disabled}
-      size={size}
+      $size={size}
       type={type}
     >
-      <Text buttonStyle={buttonStyle}>{children}</Text>
+      <Text $buttonStyle={buttonStyle}>{children}</Text>
       {icon && <Icon name={icon} prefix={iconPrefix} />}
     </ILegoButton>
   );
@@ -80,9 +80,9 @@ export default LegoButton;
 /** Styles **/
 
 interface LegoButtonStyleProps {
-  buttonStyle: ButtonStyle;
+  $buttonStyle: ButtonStyle;
   disabled?: boolean;
-  size?: "small" | "normal";
+  $size?: "small" | "normal";
 }
 
 const ILegoRouterLink = styled(Link)<LegoButtonStyleProps>`
@@ -97,26 +97,26 @@ const ILegoRouterLink = styled(Link)<LegoButtonStyleProps>`
   }
 
   /** Primary style (also base for tertiary) **/
-  ${(props) =>
-    (props.buttonStyle === "primary" || props.buttonStyle === "tertiary") &&
+  ${({ $buttonStyle }) =>
+    ($buttonStyle === "primary" || $buttonStyle === "tertiary") &&
     css<LegoButtonStyleProps>`
       background: var(--lego-red);
       color: var(--lego-white);
       border: 1px solid #bd1c1c;
       box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
       border-radius: 10px;
-      padding: ${(props) =>
-        props.size === "small" ? "7.5px 15px" : "10px 30px"};
+      padding: ${({ $size }) =>
+        $size === "small" ? "7.5px 15px" : "10px 30px"};
 
       > i {
-        margin-left: ${(props) => (props.size === "small" ? "10px" : "25px")};
-        font-size: ${(props) => (props.size === "small" ? "1.2rem" : "1.8rem")};
+        margin-left: ${({ $size }) => ($size === "small" ? "10px" : "25px")};
+        font-size: ${({ $size }) => ($size === "small" ? "1.2rem" : "1.8rem")};
       }
     `}
 
   /** Secondary style **/
-  ${(props) =>
-    props.buttonStyle === "secondary" &&
+  ${({ $buttonStyle }) =>
+    $buttonStyle === "secondary" &&
     css`
       color: var(--lego-red);
 
@@ -134,17 +134,17 @@ const ILegoRouterLink = styled(Link)<LegoButtonStyleProps>`
     `}
 
   /** Tertiary style **/
-  ${(props) =>
-    props.buttonStyle === "tertiary" &&
+  ${({ $buttonStyle }) =>
+    $buttonStyle === "tertiary" &&
     css`
       background: var(--lego-font-color);
       border: 1px solid var(--lego-font-color);
     `}
 
   /** Disabled primary & tertiary style **/
-  ${(props) =>
-    props.disabled &&
-    (props.buttonStyle === "primary" || props.buttonStyle === "tertiary") &&
+  ${({ disabled, $buttonStyle }) =>
+    disabled &&
+    ($buttonStyle === "primary" || $buttonStyle === "tertiary") &&
     css`
       background: var(--lego-gray-medium);
       border: 1px solid var(--lego-gray-dark);
@@ -161,16 +161,16 @@ const Text = styled.span<LegoButtonStyleProps>`
   font-family: var(--font-family);
 
   /** Primary style & Tertiary style **/
-  ${(props) =>
-    (props.buttonStyle === "primary" || props.buttonStyle === "tertiary") &&
+  ${({ $buttonStyle }) =>
+    ($buttonStyle === "primary" || $buttonStyle === "tertiary") &&
     css<LegoButtonStyleProps>`
-      font-size: ${(props) => (props.size === "small" ? "1rem" : "1.2rem")};
+      font-size: ${({ $size }) => ($size === "small" ? "1rem" : "1.2rem")};
       margin-bottom: 3px;
     `}
 
   /** Secondary style **/
-  ${(props) =>
-    props.buttonStyle === "secondary" &&
+  ${({ $buttonStyle }) =>
+    $buttonStyle === "secondary" &&
     css`
       font-size: 1.1rem;
       display: inline-block;

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -5,31 +5,36 @@ import AbakusLogo from "src/components/AbakusLogo";
 import NavItem from "./NavItem";
 import { media } from "src/styles/mediaQueries";
 import { User } from "src/types";
+import { useParams } from "react-router-dom";
 
 interface NavBarProps {
   user: User;
   isEditing: boolean;
 }
 
-const NavBar: React.FC<NavBarProps> = ({ user, isEditing }) => (
-  <Container>
-    <BrandContainer>
-      <AbakusLogo />
-    </BrandContainer>
-    {!user.has_application || isEditing ? (
-      <NavItemsContainer>
-        <NavItem to="./velg-komiteer" text="Velg komiteer" />
-        <NavItem to="./min-soknad" text="Min søknad" />
-      </NavItemsContainer>
-    ) : (
-      <NavItemsContainer>
-        <NavItem to="./min-soknad" text="Min søknad" />
-      </NavItemsContainer>
-    )}
+const NavBar: React.FC<NavBarProps> = ({ user, isEditing }) => {
+  const { admissionId } = useParams();
 
-    <UserInfo user={user} />
-  </Container>
-);
+  return (
+    <Container>
+      <BrandContainer>
+        <AbakusLogo />
+      </BrandContainer>
+      {!user.has_application || isEditing ? (
+        <NavItemsContainer>
+          <NavItem to={`/${admissionId}/velg-komiteer`} text="Velg komiteer" />
+          <NavItem to={`/${admissionId}/min-soknad`} text="Min søknad" />
+        </NavItemsContainer>
+      ) : (
+        <NavItemsContainer>
+          <NavItem to={`/${admissionId}/min-soknad`} text="Min søknad" />
+        </NavItemsContainer>
+      )}
+
+      <UserInfo user={user} />
+    </Container>
+  );
+};
 
 export default NavBar;
 

--- a/frontend/src/components/styledFields/index.tsx
+++ b/frontend/src/components/styledFields/index.tsx
@@ -4,7 +4,7 @@ import { Field } from "formik";
 import Textarea from "react-textarea-autosize";
 
 interface StyledFieldProps {
-  error?: boolean;
+  $error?: boolean;
 }
 
 export const StyledField = styled(Field)<StyledFieldProps>`
@@ -42,7 +42,7 @@ export const StyledTextAreaField = styled(Textarea)<StyledFieldProps>`
   font-family: var(--font-family);
   color: var(--lego-font-color);
   border: 2px solid
-    ${(props) => (props.error ? "var(--lego-red)" : "var(--lego-gray-medium)")};
+    ${({ $error }) => ($error ? "var(--lego-red)" : "var(--lego-gray-medium)")};
   border-radius: 13px;
   box-shadow: inset 0px 4px 4px rgba(129, 129, 129, 0.1);
   overflow: hidden;

--- a/frontend/src/containers/GroupApplication/Application.tsx
+++ b/frontend/src/containers/GroupApplication/Application.tsx
@@ -57,7 +57,7 @@ const Application: React.FC<ApplicationProps> = ({
           onBlur={handleBlur}
           placeholder="Skriv søknadstekst her..."
           value={value}
-          error={!!error}
+          $error={!!error}
           rows={10}
           disabled={disabled}
         />

--- a/frontend/src/routes/ApplicationForm/FormStructure.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.tsx
@@ -125,7 +125,7 @@ const FormStructure: React.FC<FormStructureProps> = ({
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to="/velg-komiteer"
+                to={`/${admission.pk}/velg-komiteer`}
               >
                 Velg komiteer
               </LegoButton>

--- a/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
+++ b/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
@@ -7,7 +7,7 @@
 
 import React from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import MiniToggleGroup from "./MiniToggleGroup";
 import { media } from "src/styles/mediaQueries";
 import { Group } from "src/types";
@@ -23,6 +23,8 @@ const ToggleGroups: React.FC<ToggleGroupsProps> = ({
   selectedGroups,
   toggleGroup,
 }) => {
+  const { admissionId } = useParams();
+
   const ChooseGroupsItems = groups.map((group, index) => (
     <MiniToggleGroup
       name={group.name}
@@ -40,7 +42,7 @@ const ToggleGroups: React.FC<ToggleGroupsProps> = ({
         Klikk på logoene til komiteene for å legge til/fjerne de fra søknaden.
       </Tooltip>
       <IconsWrapper>{ChooseGroupsItems}</IconsWrapper>
-      <LinkToOverview to="/velg-komiteer">
+      <LinkToOverview to={`/${admissionId}/velg-komiteer`}>
         Eller gå tilbake til oversikten for å lese mer
       </LinkToOverview>
     </Wrapper>

--- a/frontend/src/routes/GroupsPage/index.tsx
+++ b/frontend/src/routes/GroupsPage/index.tsx
@@ -48,7 +48,7 @@ const GroupsPage: React.FC<GroupsPageProps> = ({
       <GroupsWrapper>{GroupCards}</GroupsWrapper>
       <NextButtonWrapper>
         <LegoButton
-          to="../min-soknad"
+          to={`/${admissionId}/min-soknad`}
           icon="arrow-forward"
           iconPrefix="ios"
           disabled={!hasSelectedAnything()}

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -204,7 +204,7 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to="/velg-komiteer"
+                to={`/${admissionId}/velg-komiteer`}
               >
                 Velg komiteer
               </LegoButton>


### PR DESCRIPTION
Props to styled components were being passed to the component itself, causing errors in the dev console when the browser tried to render them. With [transient props](https://styled-components.com/docs/api#transient-props) this is no longer the case.

Sub-admission navigation had some incorrect relative paths, and now they don't.

No visual changes