### PR TITLE
Make create-application use the correct admisison

### DIFF
--- a/admissions/admissions/serializers.py
+++ b/admissions/admissions/serializers.py
@@ -52,6 +52,7 @@ class AdmissionListPublicSerializer(serializers.HyperlinkedModelSerializer):
             "public_deadline",
             "application_deadline",
             "is_closed",
+            "is_appliable",
         )
 
 
@@ -96,7 +97,7 @@ class AdminCreateUpdateAdmissionSerializer(serializers.HyperlinkedModelSerialize
         return self.update_or_create(instance.pk, validated_data)
 
 
-class AdminAdmissionSerializer(serializers.HyperlinkedModelSerializer):
+class AdminAdmissionSerializer(serializers.ModelSerializer):
     applications = UserApplication.objects.all()
     groups = GroupSerializer(source="group_set", many=True)
 
@@ -111,6 +112,9 @@ class AdminAdmissionSerializer(serializers.HyperlinkedModelSerializer):
             "public_deadline",
             "application_deadline",
             "applications",
+            "is_open",
+            "is_closed",
+            "is_appliable",
         )
 
 
@@ -192,7 +196,7 @@ class ApplicationCreateUpdateSerializer(serializers.HyperlinkedModelSerializer):
         text = validated_data.pop("text")
         phone_number = validated_data.pop("phone_number")
 
-        admission = [obj for obj in Admission.objects.all() if obj.is_open][0]
+        admission = Admission.objects.get(pk=validated_data.get("admission_id"))
 
         user_application, created = UserApplication.objects.update_or_create(
             admission=admission,

--- a/admissions/admissions/views.py
+++ b/admissions/admissions/views.py
@@ -126,7 +126,8 @@ class ApplicationViewSet(viewsets.ModelViewSet):
         return UserApplicationSerializer
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        admission_id = self.kwargs.get("admission_pk", None)
+        serializer.save(user=self.request.user, admission_id=admission_id)
 
     @action(detail=True, methods=["DELETE"], url_name="delete_group_application")
     def delete_group_application(self, request, admission_pk, pk=None):

--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -58,19 +58,19 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
           )}
         </TimeLineWrapper>
         <CountDownWrapper>
-          {!admission.is_open && (
+          {!admission.is_open && !admission.is_closed && (
             <CountDown
               title="Opptaket åpner om"
               dateString={admission.open_from}
             />
           )}
-          {admission.is_open && !admission.is_closed && (
+          {admission.is_appliable && (
             <CountDown
               title="Søknadsfrist om"
               dateString={admission.public_deadline}
             />
           )}
-          {admission.is_open && admission.is_closed && (
+          {!admission.is_appliable && admission.is_open && (
             <CountDown
               title="Redigeringsfrist om"
               dateString={admission.application_deadline}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,7 @@ export interface Admission {
   title: string;
   description: string;
   is_open: boolean;
+  is_appliable: boolean;
   is_closed: boolean;
   open_from: string;
   public_deadline: string;


### PR DESCRIPTION
Previously the applications only used the first available admission that was open..

Also fixed a minor bug where the admin-view didn't send is_open and is_closed to the frontend resulting in the wrong data being displayed.

Resolves ABA-322