### PR TITLE
Delete and view application after deadline

### DIFF
--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -77,7 +77,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
             />
           )}
           <LinkWrapper>
-            {djangoData.user.full_name ? (
+            {(admission.is_open || hasSubmitted) && (djangoData.user.full_name ? (
               <li>
                 <LegoButton
                   to={
@@ -104,7 +104,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
                   Gå til søknad
                 </LegoButton>
               </li>
-            )}
+            ))}
 
             {djangoData.user.is_privileged && (
               <li>

--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -77,34 +77,35 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
             />
           )}
           <LinkWrapper>
-            {(admission.is_open || hasSubmitted) && (djangoData.user.full_name ? (
-              <li>
-                <LegoButton
-                  to={
-                    `/${admission.pk}/` +
-                    (hasSubmitted ? "min-soknad" : "velg-komiteer")
-                  }
-                  icon="arrow-forward"
-                  iconPrefix="ios"
-                >
-                  Gå til søknad
-                </LegoButton>
-              </li>
-            ) : (
-              <li>
-                <LegoButton
-                  icon="arrow-forward"
-                  iconPrefix="ios"
-                  disabled={!admission.is_open}
-                  onClick={(e) => {
-                    (window as Window).location = "/login/lego/";
-                    e.preventDefault();
-                  }}
-                >
-                  Gå til søknad
-                </LegoButton>
-              </li>
-            ))}
+            {(admission.is_open || hasSubmitted) &&
+              (djangoData.user.full_name ? (
+                <li>
+                  <LegoButton
+                    to={
+                      `/${admission.pk}/` +
+                      (hasSubmitted ? "min-soknad" : "velg-komiteer")
+                    }
+                    icon="arrow-forward"
+                    iconPrefix="ios"
+                  >
+                    Gå til søknad
+                  </LegoButton>
+                </li>
+              ) : (
+                <li>
+                  <LegoButton
+                    icon="arrow-forward"
+                    iconPrefix="ios"
+                    disabled={!admission.is_open}
+                    onClick={(e) => {
+                      (window as Window).location = "/login/lego/";
+                      e.preventDefault();
+                    }}
+                  >
+                    Gå til søknad
+                  </LegoButton>
+                </li>
+              ))}
 
             {djangoData.user.is_privileged && (
               <li>

--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -34,7 +34,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
               </React.Fragment>
             ))}
           </AdmissionDescription>
-          {!admission.is_open && (
+          {!admission.is_open && !admission.is_closed && (
             <TimeLineItem
               title="Opptaket åpner"
               dateString={admission.open_from}
@@ -46,7 +46,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
             dateString={admission.public_deadline}
             details={["Alle søknader er garantert å behandlet."]}
           />
-          {admission.is_open && (
+          {(admission.is_open || admission.is_closed) && (
             <TimeLineItem
               title="Redigeringsfrist"
               dateString={admission.application_deadline}
@@ -77,36 +77,34 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
             />
           )}
           <LinkWrapper>
-            {admission.is_open &&
-              (djangoData.user.full_name ? (
-                <li>
-                  <LegoButton
-                    to={
-                      `/${admission.pk}/` +
-                      (hasSubmitted ? "min-soknad" : "velg-komiteer")
-                    }
-                    icon="arrow-forward"
-                    iconPrefix="ios"
-                    disabled={!admission.is_open}
-                  >
-                    Gå til søknad
-                  </LegoButton>
-                </li>
-              ) : (
-                <li>
-                  <LegoButton
-                    icon="arrow-forward"
-                    iconPrefix="ios"
-                    disabled={!admission.is_open}
-                    onClick={(e) => {
-                      (window as Window).location = "/login/lego/";
-                      e.preventDefault();
-                    }}
-                  >
-                    Gå til søknad
-                  </LegoButton>
-                </li>
-              ))}
+            {djangoData.user.full_name ? (
+              <li>
+                <LegoButton
+                  to={
+                    `/${admission.pk}/` +
+                    (hasSubmitted ? "min-soknad" : "velg-komiteer")
+                  }
+                  icon="arrow-forward"
+                  iconPrefix="ios"
+                >
+                  Gå til søknad
+                </LegoButton>
+              </li>
+            ) : (
+              <li>
+                <LegoButton
+                  icon="arrow-forward"
+                  iconPrefix="ios"
+                  disabled={!admission.is_open}
+                  onClick={(e) => {
+                    (window as Window).location = "/login/lego/";
+                    e.preventDefault();
+                  }}
+                >
+                  Gå til søknad
+                </LegoButton>
+              </li>
+            )}
 
             {djangoData.user.is_privileged && (
               <li>

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -95,13 +95,15 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
             </Notice>
           </EditInfo>
           <EditActions>
-            <LegoButton
-              icon="arrow-forward"
-              iconPrefix="ios"
-              onClick={toggleIsEditing}
-            >
-              Endre søknad
-            </LegoButton>
+            {admission && admission.is_open && (
+              <LegoButton
+                icon="arrow-forward"
+                iconPrefix="ios"
+                onClick={toggleIsEditing}
+              >
+                Endre søknad
+              </LegoButton>
+            )}
             <ConfirmModal
               title="Slett søknad"
               Component={({ onClick }) => (


### PR DESCRIPTION
Updated information shown after deadline to users, and added the button to view application after deadline. Users cannot edit after deadline however, and cannot create new applications if they delete their old one after the deadline.

Fixes ABA-409