### PR TITLE
Replace fetch with axios and fix slug-validation

### DIFF
--- a/admissions/admissions/models.py
+++ b/admissions/admissions/models.py
@@ -75,7 +75,7 @@ class Group(models.Model):
 
 class Admission(models.Model):
     title = models.CharField(max_length=255, unique=True)
-    slug = models.SlugField(max_length=200, unique=True)
+    slug = models.SlugField(max_length=200, unique=True, null=False)
     description = models.TextField(default="", blank=True)
     open_from = models.DateTimeField()
     public_deadline = models.DateTimeField()

--- a/admissions/admissions/tests/test_api.py
+++ b/admissions/admissions/tests/test_api.py
@@ -68,7 +68,7 @@ class EditGroupTestCase(APITestCase):
 
         self.edit_group_data = {
             "response_text": "Halla, Webkom er ikke noe gucci",
-            "description": "Webkoms maskott er en ku(le)",
+            "description": "Webkoms maskott er en rød ku(le)",
         }
 
     def test_pleb_cannot_edit_group(self):

--- a/admissions/admissions/views.py
+++ b/admissions/admissions/views.py
@@ -175,7 +175,6 @@ class ApplicationViewSet(viewsets.ModelViewSet):
 
 
 class AdminAdmissionViewSet(viewsets.ModelViewSet):
-    queryset = Admission.objects.all().order_by("open_from")
     authentication_classes = [SessionAuthentication]
     permission_classes = [
         permissions.IsAuthenticated,
@@ -191,9 +190,10 @@ class AdminAdmissionViewSet(viewsets.ModelViewSet):
             return AdminCreateUpdateAdmissionSerializer
 
     def get_queryset(self):
-        if self.request.user.is_member_of_webkom:
-            return self.queryset
-        return self.queryset.filter(created_by=self.request.user)
+        qs = Admission.objects.all().order_by("open_from")
+        if not self.request.user.is_member_of_webkom:
+            return qs.filter(created_by=self.request.user)
+        return qs
 
     def perform_create(self, serializer):
         serializer.save(created_by=self.request.user)

--- a/frontend/src/query/hooks.ts
+++ b/frontend/src/query/hooks.ts
@@ -1,19 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { Admission, Application, Group } from "src/types";
-
-interface QueryError {
-  message: string;
-  code?: number;
-}
 
 // Admin hooks
 
 export const useAdminAdmissions = () => {
-  return useQuery<Admission[], QueryError>(["/admin/admission/"]);
+  return useQuery<Admission[], AxiosError>(["/admin/admission/"]);
 };
 
 export const useAdminAdmission = (slug: string, enabled = true) => {
-  return useQuery<Admission, QueryError>([`/admin/admission/${slug}/`], {
+  return useQuery<Admission, AxiosError>([`/admin/admission/${slug}/`], {
     enabled,
   });
 };
@@ -21,25 +17,25 @@ export const useAdminAdmission = (slug: string, enabled = true) => {
 // User hooks
 
 export const useAdmissions = () => {
-  return useQuery<Admission[], QueryError>(["/admission/"]);
+  return useQuery<Admission[], AxiosError>(["/admission/"]);
 };
 
 export const useAdmission = (slug: string) => {
-  return useQuery<Admission, QueryError>([`/admission/${slug}/`]);
+  return useQuery<Admission, AxiosError>([`/admission/${slug}/`]);
 };
 
 export const useApplications = (slug: string) => {
-  return useQuery<Application[], QueryError>([
+  return useQuery<Application[], AxiosError>([
     `/admission/${slug}/application/`,
   ]);
 };
 
 export const useMyApplication = (slug: string) => {
-  return useQuery<Application, QueryError>([
+  return useQuery<Application, AxiosError>([
     `/admission/${slug}/application/mine/`,
   ]);
 };
 
 export const useGroups = () => {
-  return useQuery<Group[], QueryError>(["/group/"]);
+  return useQuery<Group[], AxiosError>(["/group/"]);
 };

--- a/frontend/src/query/queries.ts
+++ b/frontend/src/query/queries.ts
@@ -1,12 +1,9 @@
-import { callApiFromQuery } from "../utils/callApi";
+import { QueryFunction, QueryKey } from "@tanstack/react-query";
+import { apiClient } from "../utils/callApi";
 
-interface defaultQueryFnProps {
-  queryKey: string[];
-}
-
-export const defaultQueryFn: any = async ({
+export const defaultQueryFn: QueryFunction<unknown, QueryKey> = async ({
   queryKey,
-}: defaultQueryFnProps) => {
-  const path = typeof queryKey === "string" ? queryKey : queryKey[0];
-  return await callApiFromQuery(path);
+}) => {
+  const path = queryKey.join("/");
+  return (await apiClient.get(path)).data;
 };

--- a/frontend/src/routes/AdminPage/form.tsx
+++ b/frontend/src/routes/AdminPage/form.tsx
@@ -69,11 +69,10 @@ const EditGroupForm: React.FC<EditGroupFormProps> = ({
               );
             },
             onError: (error) => {
-              const errors: { [key: string]: string } = {};
-              Object.keys(error).forEach((key) => {
-                errors[key] = error[key][0];
+              setErrors({
+                description: error.response?.data.description[0],
+                response_label: error.response?.data.response_label[0],
               });
-              setErrors(errors);
             },
           }
         );

--- a/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
@@ -5,7 +5,9 @@ export const PageWrapper = styled.div`
   width: 100%;
   padding: 0 1rem;
   margin: 0 auto 4em auto;
-  min-height: 100vh;
+  min-height: calc(
+    100vh - 70px - 2rem - 4em
+  ); /* Calculated to never overflow navbar/padding/margin */
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/routes/ApplicationPortal.tsx
+++ b/frontend/src/routes/ApplicationPortal.tsx
@@ -92,7 +92,7 @@ const ApplicationPortal = () => {
   if (!djangoData.user) {
     return null;
   } else if (error) {
-    if (error.code === 404) {
+    if (error.response?.status === 404) {
       return <NotFoundPage />;
     }
     return <div>Error: {error.message}</div>;
@@ -162,5 +162,5 @@ export const PageWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-height: 100vh;
+  min-height: calc(100vh - 70px);
 `;

--- a/frontend/src/routes/GroupsPage/index.tsx
+++ b/frontend/src/routes/GroupsPage/index.tsx
@@ -74,7 +74,9 @@ export const PageWrapper = styled.div`
   width: 100%;
   padding: 0 1rem;
   margin: 0 auto 4em auto;
-  min-height: 100vh;
+  min-height: calc(
+    100vh - 70px - 2rem - 4em
+  ); /* Calculated to never overflow navbar/padding/margin */
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/frontend/src/utils/callApi.ts
+++ b/frontend/src/utils/callApi.ts
@@ -1,72 +1,31 @@
 import Cookie from "js-cookie";
 import * as Sentry from "@sentry/browser";
 import config from "src/utils/config";
-import "whatwg-fetch";
+import axios, { AxiosError, AxiosResponse } from "axios";
 
-export class HttpError extends Error {
-  code: number;
-  constructor(message: string, errorCode: number) {
-    super(message);
-    this.code = errorCode;
-  }
-}
+/**
+ * API base
+ */
+export const apiClient = axios.create({
+  baseURL: config.API_URL,
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-CSRFToken": Cookie.get("csrftoken") ?? "",
+  },
+  timeout: 20000,
+});
 
-function reportToSentry(error: any) {
-  try {
-    if (error.response) {
-      Sentry.setContext("response", {
-        response: error.response,
-      });
-    }
-  } catch (e) {
-    //
+/**
+ * Report errors to sentry
+ */
+axios.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  (error: AxiosError) => {
+    Sentry.setContext("response", {
+      response: error.response,
+    });
+    Sentry.captureException(error);
+    return Promise.reject(error);
   }
-  Sentry.captureException(error);
-  throw error;
-}
-function timeoutPromise(ms = 0) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  }).then(() => {
-    throw new Error("HTTP request timed out.");
-  });
-}
-
-interface CallApiParams {
-  method?: string;
-  body?: string | null;
-}
-
-const _callApiFromQuery = async (
-  url: string,
-  { method = "GET", body = null }: CallApiParams = {}
-) => {
-  const request = new Request(`${config.API_URL}${url}`, {
-    method,
-    headers: new Headers({
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "X-CSRFToken": Cookie.get("csrftoken") ?? "",
-      "Access-Control-Allow-Credentials": "true",
-    }),
-    redirect: "manual",
-    credentials: "include",
-    // IE don't support body equal to null
-    ...(body ? { body } : {}),
-  });
-  const response = await Promise.race([timeoutPromise(20000), fetch(request)]);
-  const contentType =
-    response.headers.get("content-type") || "application/json";
-  const contentLength =
-    parseInt(response.headers.get("content-length") ?? "0", 10) || 0;
-  if (String(response.status)[0] !== "2") {
-    throw new HttpError(response.statusText, response.status);
-  }
-  if (contentType.includes("application/json") && contentLength !== 0) {
-    return await response.json();
-  }
-  const responseText = await response.text();
-  return responseText;
-};
-export const callApiFromQuery: typeof _callApiFromQuery = (...input) =>
-  _callApiFromQuery(...input).catch(reportToSentry);
+);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sentry/browser": "^7.48.0",
     "@tanstack/react-query": "^4.29.3",
     "@tanstack/react-table": "^8.8.5",
+    "axios": "^1.4.0",
     "formik": "^2.2.9",
     "js-cookie": "^3.0.1",
     "luxon": "^3.3.0",
@@ -30,8 +31,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "6.10.0",
     "react-textarea-autosize": "^8.4.1",
-    "styled-components": "5.3.9",
-    "whatwg-fetch": "^3.6.2"
+    "styled-components": "5.3.9"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,6 +882,20 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 "babel-plugin-styled-components@>= 1.12.0":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
@@ -1016,6 +1030,13 @@ colord@^2.9.3:
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1124,6 +1145,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1459,6 +1485,20 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 formik@^2.2.9:
   version "2.2.9"
@@ -2063,6 +2103,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -2358,6 +2410,11 @@ property-expr@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
   integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -2992,11 +3049,6 @@ vite@^4.3.3:
     rollup "^3.21.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
-whatwg-fetch@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Replace fetch with axios to;
* shorten the amount of code required to perform API calls
* Enhance typing of the error responses
* Make a bigger chunk of the error response available to facilitate better error handling

Apparently django didn't do the magic validation I thought that it did in #1014 :'( so I fixed up a bit of that while I was at it (and added it to some older code that had frontend validation only + fixed up the tests to make it work). And a little bug with the admin-admission queryset not reloading until the backend reloaded.

Resolves ABA-459