### PR TITLE
Add login button to landing page

### DIFF
--- a/frontend/src/routes/LandingPage/LandingPageSkeleton.tsx
+++ b/frontend/src/routes/LandingPage/LandingPageSkeleton.tsx
@@ -26,6 +26,9 @@ const LandingPageSkeleton: React.FC<PropsWithChildren> = ({ children }) => {
           </LegoButton>
         </LegoButtonWrapper>
       )}
+      <BottomLinkWrapper>
+        {!djangoData.user.full_name && <a href="/login/lego/">Logg inn</a>}
+      </BottomLinkWrapper>
     </Container>
   );
 };
@@ -39,9 +42,10 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   margin: 0 auto;
-  padding: 2rem 0 2rem 0;
+  padding-top: 2rem;
   width: 80%;
   max-width: 100%;
+  min-height: 100vh;
   ${media.portrait`
     width: 90%;
   `}
@@ -70,4 +74,12 @@ const Title = styled.h1`
 
 const LegoButtonWrapper = styled.div`
   margin-top: 3em;
+`;
+
+const BottomLinkWrapper = styled.div`
+  display: flex;
+  flex-grow: 1;
+  align-items: flex-end;
+  padding-top: 2rem;
+  padding-bottom: 0.2rem;
 `;


### PR DESCRIPTION
Add a link to login from the landing page - this makes it so that even if there are no active admissions you can still login without manually visiting `/login/lego/`.

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/13599770/236676261-664d7ee7-2579-43e7-a3df-ea290d1bfcc5.png">

