### PR TITLE
Update admin-site to support json schema

### DIFF
--- a/frontend/src/components/Application/index.tsx
+++ b/frontend/src/components/Application/index.tsx
@@ -5,18 +5,30 @@ import ReadMore from "src/components/ReadMore";
 import Wrapper from "./Wrapper";
 import GroupName from "./GroupName";
 import DeleteApplication from "./DeleteApplication";
+import { JsonFieldInput } from "src/types";
+import { filterEditableFields } from "src/utils/jsonFieldHelper";
 
 interface ApplicationProps {
-  text: string;
+  questions: JsonFieldInput[];
+  responses: Record<string, string>;
   applicationId: number;
 }
 
-const Application: React.FC<ApplicationProps> = ({ text, applicationId }) => {
+const Application: React.FC<ApplicationProps> = ({
+  questions,
+  responses,
+  applicationId,
+}) => {
   return (
     <div>
       <GroupName>Søknad</GroupName>
       <Wrapper>
-        <ReadMore truncateLength={400} text={text} />
+        <ReadMore
+          truncateLength={400}
+          text={filterEditableFields(questions)
+            .map((question) => question.name + ":\n" + responses[question.id])
+            .join("\n\n")}
+        />
       </Wrapper>
       <DeleteApplication applicationId={applicationId} />
     </div>

--- a/frontend/src/components/InputValidationFeedback/index.tsx
+++ b/frontend/src/components/InputValidationFeedback/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./styles.css";
 
 interface InputValidationFeedbackProps {
-  error: string;
+  error?: string;
 }
 
 const InputValidationFeedback: React.FC<InputValidationFeedbackProps> = ({

--- a/frontend/src/components/JsonFieldEditor/PhoneInput.tsx
+++ b/frontend/src/components/JsonFieldEditor/PhoneInput.tsx
@@ -1,0 +1,25 @@
+import { Field } from "formik";
+import React from "react";
+import { JsonFieldPhoneInput } from "src/types";
+import { StyledField } from "../styledFields";
+
+type PhoneInputProps = {
+  field: JsonFieldPhoneInput;
+  index: number;
+};
+
+const PhoneInput: React.FC<PhoneInputProps> = ({ field, index }) => {
+  return (
+    <>
+      <p>Telefonnummer</p>
+      <StyledField
+        name={"questions." + index + ".name"}
+        placeholder={""}
+        label={"Label"}
+      />
+      <StyledField name={"questions." + index + ".label"} label={"Label"} />
+    </>
+  );
+};
+
+export default PhoneInput;

--- a/frontend/src/components/JsonFieldEditor/Text.tsx
+++ b/frontend/src/components/JsonFieldEditor/Text.tsx
@@ -1,0 +1,24 @@
+import { Field } from "formik";
+import React from "react";
+import { JsonFieldText } from "src/types";
+import TextAreaField from "src/components/TextAreaField";
+
+type TextProps = {
+  field: JsonFieldText;
+  index: number;
+};
+
+const Text: React.FC<TextProps> = ({ field, index }) => {
+  return (
+    <>
+      <p>Informasjonstekst</p>
+      <Field
+        name={"questions." + index + ".text"}
+        component={TextAreaField}
+        placeholder={""}
+      />
+    </>
+  );
+};
+
+export default Text;

--- a/frontend/src/components/JsonFieldEditor/TextArea.tsx
+++ b/frontend/src/components/JsonFieldEditor/TextArea.tsx
@@ -1,0 +1,30 @@
+import { Field } from "formik";
+import React from "react";
+import { JsonFieldTextArea } from "src/types";
+import { StyledField } from "../styledFields";
+import TextAreaField from "../TextAreaField";
+
+type TextAreaProps = {
+  field: JsonFieldTextArea;
+  index: number;
+};
+
+const TextArea: React.FC<TextAreaProps> = ({ field, index }) => {
+  return (
+    <>
+      <p>Langtekst-svar</p>
+      <StyledField
+        name={"questions." + index + ".name"}
+        placeholder={""}
+        label={"Label"}
+      />
+      <Field
+        name={"questions." + index + ".label"}
+        component={TextAreaField}
+        placeholder={""}
+      />
+    </>
+  );
+};
+
+export default TextArea;

--- a/frontend/src/components/JsonFieldEditor/TextInput.tsx
+++ b/frontend/src/components/JsonFieldEditor/TextInput.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { JsonFieldTextInput } from "src/types";
+import { StyledField } from "../styledFields";
+
+type TextInputProps = {
+  field: JsonFieldTextInput;
+  index: number;
+};
+
+const TextInput: React.FC<TextInputProps> = ({ field, index }) => {
+  return (
+    <>
+      <p>Korttekst-svar</p>
+      <StyledField
+        name={"questions." + index + ".name"}
+        placeholder={""}
+        label={"Label"}
+      />
+      <StyledField
+        name={"questions." + index + ".label"}
+        placeholder={""}
+        label={"Label"}
+      />
+    </>
+  );
+};
+
+export default TextInput;

--- a/frontend/src/components/JsonFieldEditor/index.tsx
+++ b/frontend/src/components/JsonFieldEditor/index.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { Group, JsonFieldInput } from "src/types";
+import styled from "styled-components";
+import PhoneInput from "./PhoneInput";
+import Text from "./Text";
+import TextArea from "./TextArea";
+import TextInput from "./TextInput";
+
+type JsonFieldEditorProps = {
+  group: Group;
+  initialFields: JsonFieldInput[];
+};
+
+const JsonFieldEditor: React.FC<JsonFieldEditorProps> = ({
+  group,
+  initialFields,
+}) => {
+  const [fields, setFields] = useState<JsonFieldInput[]>(initialFields);
+
+  return (
+    <EditorWrapper>
+      <h3>Rediger spørsmål for {group.name}</h3>
+      <FieldWrapper>
+        {fields.map((field, index) => {
+          if (field.type === "text")
+            return <Text key={index} field={field} index={index} />;
+          if (field.type === "textarea")
+            return <TextArea key={field.id} field={field} index={index} />;
+          if (field.type === "phoneinput")
+            return <PhoneInput key={field.id} field={field} index={index} />;
+          if (field.type === "textinput")
+            return <TextInput key={field.id} field={field} index={index} />;
+          return null;
+        })}
+      </FieldWrapper>
+    </EditorWrapper>
+  );
+};
+
+export default JsonFieldEditor;
+
+const EditorWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+  width: 100%;
+  margin-bottom: 1em;
+
+  h3 {
+    margin: 0;
+  }
+`;
+
+const FieldWrapper = styled.div`
+  p {
+    margin: 0;
+  }
+  input {
+    display: block;
+  }
+`;

--- a/frontend/src/containers/AdmissionsContainer/Columns.tsx
+++ b/frontend/src/containers/AdmissionsContainer/Columns.tsx
@@ -5,6 +5,8 @@ import FormatTime from "src/components/Time/FormatTime";
 import { AdmissionsTableValues } from ".";
 import { InnerTableValues } from "./InnerTable";
 import DeleteApplication from "src/components/Application/DeleteApplication";
+import { JsonFieldEditableInput } from "src/types";
+import { filterEditableFields } from "src/utils/jsonFieldHelper";
 
 const columnHelper = createColumnHelper<AdmissionsTableValues>();
 
@@ -28,9 +30,6 @@ export const columns = [
   }),
   columnHelper.accessor("fullname", {
     header: "Fullt navn",
-  }),
-  columnHelper.accessor("phoneNumber", {
-    header: "Tlf.",
   }),
   columnHelper.accessor("email", {
     header: "E-post",
@@ -81,9 +80,16 @@ export const innerColumns = [
     header: "Gruppe",
     size: 100,
   }),
-  innerColumnHelper.accessor("text", {
+  innerColumnHelper.accessor("responses", {
     header: "Søknadstekst",
     size: 800,
+    cell: ({ row }) =>
+      filterEditableFields(row.original.groupQuestions).map((question) => (
+        <div key={question.id}>
+          <h3>{question.name}</h3>
+          <span>{row.original.responses[question.id]}</span>
+        </div>
+      )),
   }),
   innerColumnHelper.display({
     id: "actions",

--- a/frontend/src/containers/AdmissionsContainer/InnerTable.tsx
+++ b/frontend/src/containers/AdmissionsContainer/InnerTable.tsx
@@ -6,11 +6,13 @@ import {
 } from "@tanstack/react-table";
 import { innerColumns } from "./Columns";
 import styled from "styled-components";
+import { JsonFieldInput } from "src/types";
 
 export interface InnerTableValues {
   applicationId: number;
   group: string;
-  text: string;
+  responses: Record<string, string>;
+  groupQuestions?: JsonFieldInput[];
 }
 
 interface AdmissionsInnerTableProps {

--- a/frontend/src/containers/UserApplication/index.tsx
+++ b/frontend/src/containers/UserApplication/index.tsx
@@ -10,17 +10,27 @@ import Name from "./Name";
 import SmallDescription from "./SmallDescription";
 import SmallDescriptionWrapper from "./SmallDescriptionWrapper";
 import Header from "./Header";
-import { Application as UserApplicationInterface } from "src/types";
+import {
+  Admission,
+  Application as UserApplicationInterface,
+  Group,
+} from "src/types";
+import { filterEditableFields } from "src/utils/jsonFieldHelper";
 
-type UserApplicationProps = UserApplicationInterface;
+type UserApplicationProps = {
+  admission: Admission;
+  currentGroup: Group;
+} & UserApplicationInterface;
 
 const UserApplication: React.FC<UserApplicationProps> = ({
+  admission,
+  currentGroup,
   user,
+  responses,
   group_applications,
   created_at,
   updated_at,
   applied_within_deadline,
-  phone_number,
   pk,
 }) => (
   <Wrapper>
@@ -47,9 +57,12 @@ const UserApplication: React.FC<UserApplicationProps> = ({
               <SmallDescription> Brukernavn </SmallDescription>
               {user.username}
             </SmallDescriptionWrapper>
-            <SmallDescriptionWrapper>
-              <SmallDescription> Tlf. </SmallDescription> {phone_number}
-            </SmallDescriptionWrapper>
+            {filterEditableFields(admission.questions).map((question) => (
+              <SmallDescriptionWrapper key={question.id}>
+                <SmallDescription>{question.name} </SmallDescription>
+                {responses[question.id]}
+              </SmallDescriptionWrapper>
+            ))}
             <SmallDescriptionWrapper>
               <SmallDescription> E-mail </SmallDescription> {user.email}
             </SmallDescriptionWrapper>
@@ -72,7 +85,8 @@ const UserApplication: React.FC<UserApplicationProps> = ({
             <Application
               applicationId={pk}
               key={user.username + "-" + groupApplication.group.name}
-              text={groupApplication.text}
+              questions={currentGroup.questions}
+              responses={groupApplication.responses}
             />
           ))}
         </div>

--- a/frontend/src/routes/AdminPage/index.tsx
+++ b/frontend/src/routes/AdminPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { useAdmission, useApplications } from "src/query/hooks";
@@ -19,43 +19,57 @@ import {
   GroupLogoWrapper,
 } from "./styles";
 import { Application } from "src/types";
+import { filterEditableFields } from "src/utils/jsonFieldHelper";
 
-export interface CsvData {
+export type BaseCsvData = {
   name: string;
   email: string;
   username: string;
-  applicationText: string;
   createdAt: string;
   updatedAt: string;
   appliedWithinDeadline: boolean;
-  phoneNumber: string;
-}
+} & Record<string, string | boolean | number>;
 
 const AdminPage = () => {
   const { admissionSlug } = useParams();
   const [sortedApplications, setSortedApplications] = useState<Application[]>(
     []
   );
-  const [csvData, setCsvData] = useState<CsvData[]>([]);
-
-  const csvHeaders = [
-    { label: "Full Name", key: "name" },
-    { label: "Søknadstekst", key: "applicationText" },
-    { label: "Mobilnummer", key: "phoneNumber" },
-    { label: "Email", key: "email" },
-    { label: "Username", key: "username" },
-    { label: "Søkt innen frist", key: "appliedWithinDeadline" },
-    { label: "Tid sendt", key: "createdAt" },
-    { label: "Tid oppdatert", key: "updatedAt" },
-  ];
+  const [csvData, setCsvData] = useState<BaseCsvData[]>([]);
 
   const { data: admission } = useAdmission(admissionSlug ?? "");
-  const { groups } = admission ?? {};
+  const currentGroup = useMemo(
+    () =>
+      admission?.groups?.find(
+        (group) => group.name === djangoData.user.representative_of_group
+      ),
+    [admission, djangoData]
+  );
   const {
     data: applications,
     isFetching,
     error,
   } = useApplications(admissionSlug ?? "");
+
+  const csvHeaders = useMemo(
+    () => [
+      { label: "Fullt navn", key: "name" },
+      { label: "E-post", key: "email" },
+      { label: "Brukernavn", key: "username" },
+      { label: "Søkt innen frist", key: "appliedWithinDeadline" },
+      { label: "Tid sendt", key: "createdAt" },
+      { label: "Tid oppdatert", key: "updatedAt" },
+      ...filterEditableFields(admission?.questions).map((question) => ({
+        label: question.name,
+        key: question.id,
+      })),
+      ...filterEditableFields(currentGroup?.questions).map((question) => ({
+        label: question.name,
+        key: question.id,
+      })),
+    ],
+    [admission, currentGroup]
+  );
 
   useEffect(() => {
     if (!applications) return;
@@ -70,19 +84,17 @@ const AdminPage = () => {
 
   useEffect(() => {
     // Push all the individual applications into csvData with the right format
-    const updatedCsvData: CsvData[] = [];
+    const updatedCsvData: BaseCsvData[] = [];
     sortedApplications.forEach((userApplication) => {
       updatedCsvData.push({
         name: userApplication.user.full_name,
         email: userApplication.user.email,
         username: userApplication.user.username,
-        applicationText: replaceQuotationMarks(
-          userApplication.group_applications[0].text
-        ),
         createdAt: userApplication.created_at,
         updatedAt: userApplication.updated_at,
         appliedWithinDeadline: userApplication.applied_within_deadline,
-        phoneNumber: userApplication.phone_number,
+        ...userApplication.responses,
+        ...userApplication.group_applications[0].responses,
       });
     });
     setCsvData(updatedCsvData);
@@ -94,31 +106,24 @@ const AdminPage = () => {
     return <div>Error: {error.message}</div>;
   } else if (isFetching) {
     return <LoadingBall />;
-  } else if (!groups) {
-    return <div>Feil: klarte ikke laste inn grupper.</div>;
-  } else {
-    const group = (groups ?? []).find(
-      (group) =>
-        group.name.toLowerCase() ===
-        djangoData.user.representative_of_group.toLowerCase()
+  } else if (!admission) {
+    return <div>Fant ikke opptaket.</div>;
+  } else if (!currentGroup) {
+    return (
+      <div>Feil: fant ingen grupper du har tilgang til å administrere.</div>
     );
-    if (!group) return <div>Feil: Ugyldig gruppe</div>;
-
+  } else {
     return (
       <PageWrapper>
         <PageTitle>Admin Panel</PageTitle>
         <GroupLogoWrapper>
-          <GroupLogo src={group.logo} />
-          <h2>{djangoData.user.representative_of_group}</h2>
+          <GroupLogo src={currentGroup.logo} />
+          <h2>{currentGroup.name}</h2>
         </GroupLogoWrapper>
         <LinkLink to="/">Gå til forside</LinkLink>
 
         <Wrapper>
-          <EditGroupForm
-            initialDescription={group && group.description}
-            initialReplyText={group && group.response_label}
-            group={group}
-          />
+          <EditGroupForm group={currentGroup} />
         </Wrapper>
         <Wrapper>
           <Statistics>
@@ -134,10 +139,15 @@ const AdminPage = () => {
             target="_blank"
           >
             Eksporter som csv
+            <br />
+            NB: Åpne CSV-filen i Google Sheets for å være sikker på at den vises
+            riktig.
           </CSVExport>
           {sortedApplications.map((userApplication) => (
             <UserApplication
               key={userApplication.user.username}
+              admission={admission}
+              currentGroup={currentGroup}
               {...userApplication}
             />
           ))}

--- a/frontend/src/utils/methods.ts
+++ b/frontend/src/utils/methods.ts
@@ -23,3 +23,39 @@ export const toggleFromArray: <T>(
  */
 export const replaceQuotationMarks = (text: string) =>
   text.replaceAll('"', "'");
+
+/**
+ *
+ * @param name
+ * @param obj
+ * @returns
+ */
+export const traverseObject: (name: string, obj: object) => string = (
+  name,
+  obj
+) =>
+  name
+    .split(".")
+    .reduce((accumulator, currentIndex) => {
+      if (typeof accumulator === "string" || !accumulator) {
+        return accumulator;
+      }
+      if (currentIndex in accumulator) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return accumulator[currentIndex];
+      }
+      return "";
+    }, obj)
+    ?.toString();
+
+export const uuidv4mock = () => {
+  return (<any>[1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
+    /[018]/g,
+    (c: number) =>
+      (
+        c ^
+        (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+      ).toString(16)
+  );
+};


### PR DESCRIPTION
For the main backend changes, see #1178.

Updates the admin-views to support viewing applications, download CSVs and edit the JSON schema.

The backend + the frontend structure supports adding fields, reordering fields, etc. but this is not implemented in the GUI yet. Would rather do this in a later PR.

The functionality to change the top questions (info and phone number in the screenshot in #1179) is not yet implemented, but will match the visual preview for group-leaders.

## Visual preview
### Admin page for group-leaders and recruiters
<img width="416" alt="image" src="https://github.com/webkom/admissions/assets/13599770/04ca6d66-a4e6-4ed6-ac80-3531988487db">

<img width="413" alt="image" src="https://github.com/webkom/admissions/assets/13599770/ad4d920c-86f4-4fcc-b9ca-bf116ff081da">

### Admin page for admission-admins
<img width="686" alt="image" src="https://github.com/webkom/admissions/assets/13599770/8560eb90-834b-4e6d-b78b-1eb29176085a">

Resolves ABA-515, ABA-516