### PR TITLE
Prepare for 2023-admission

### DIFF
--- a/frontend/src/components/ConfirmModal/index.tsx
+++ b/frontend/src/components/ConfirmModal/index.tsx
@@ -52,7 +52,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
             border="1px solid darkgray"
             onClick={hideModal}
           >
-            Cancel
+            Avbryt
           </ActionButton>
           <ActionButton onClick={confirmAction}>Ja</ActionButton>
         </ButtonGroup>

--- a/frontend/src/components/ConfirmModal/styles.tsx
+++ b/frontend/src/components/ConfirmModal/styles.tsx
@@ -10,6 +10,7 @@ export const Overlay = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: 100;
 `;
 
 export const ConfirmBox = styled.div`

--- a/frontend/src/containers/GroupApplication/index.tsx
+++ b/frontend/src/containers/GroupApplication/index.tsx
@@ -1,22 +1,7 @@
-import React, { useEffect } from "react";
-import { getApplictionTextDrafts } from "src/utils/draftHelper";
+import React from "react";
 import Application, { ApplicationProps } from "./Application";
 
 const GroupApplication = (props: ApplicationProps) => {
-  useEffect(() => {
-    initializeValue();
-  }, []);
-
-  const initializeValue = () => {
-    const groupName = props.group.name.toLowerCase();
-
-    const restoredApplicationText = getApplictionTextDrafts();
-
-    if (restoredApplicationText != null && restoredApplicationText[groupName]) {
-      props.form.setFieldValue(groupName, restoredApplicationText[groupName]);
-    }
-  };
-
   return <Application {...props} />;
 };
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -31,8 +31,8 @@ Sentry.init({
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: process.env.NODE_ENV === "production",
-      refetchOnWindowFocus: process.env.NODE_ENV === "production",
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
       queryFn: defaultQueryFn,
       staleTime: 60000,
     },

--- a/frontend/src/routes/ApplicationForm/FormStructure.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.tsx
@@ -76,25 +76,9 @@ const FormStructure: React.FC<FormStructureProps> = ({
           <SectionHeader>Generelt</SectionHeader>
           <HelpText>
             <Icon name="information-circle-outline" />
-            Mobilnummeret vil bli brukt til å kalle deg inn på intervju av
-            komitéledere.
+            Mobilnummeret vil bli brukt til å kalle deg inn på intervju.
           </HelpText>
           <Field name="phoneNumber" component={PhoneNumberField} />
-
-          <HelpText>
-            <Icon name="information-circle-outline" />
-            Kun leder av Abakus kan se det du skriver inn i prioriterings- og
-            kommentarfeltet.
-            <Icon name="information-circle-outline" />
-            Det er ikke sikkert prioriteringslisten vil bli tatt hensyn til.
-            Ikke søk på en komité du ikke ønsker å bli med i.
-          </HelpText>
-          <Field
-            name="priorityText"
-            component={PriorityTextField}
-            label="Prioriteringer, og andre kommentarer"
-            optional
-          />
         </GeneralInfoSection>
         <SeparatorLine />
         <GroupsSection>
@@ -105,6 +89,11 @@ const FormStructure: React.FC<FormStructureProps> = ({
                 <Icon name="information-circle-outline" />
                 Her skriver du søknaden til komiteen(e) du har valgt. Hver
                 komité kan kun se søknaden til sin egen komité.
+              </HelpText>
+              <HelpText>
+                <Icon name="information-circle-outline" />
+                Søknadene vil brukes i opptaksprosessen, men alle søkere vil bli
+                kalt inn til intervju.
               </HelpText>
 
               <ToggleGroups

--- a/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
@@ -200,7 +200,7 @@ export const Sidebar = styled.div`
     }
 
     > span {
-      margin-top: calc(0.5rem);
+      margin-top: 0.5rem;
       margin-bottom: 0.9rem;
     }
 

--- a/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
@@ -196,12 +196,16 @@ export const Sidebar = styled.div`
     top: 2rem;
 
     > h2 {
-      margin-bottom: -1.5rem;
+      margin-bottom: 0.5rem;
     }
 
     > span {
-      margin-top: calc(1rem + 16px);
-      margin-bottom: 2rem;
+      margin-top: calc(0.5rem);
+      margin-bottom: 0.9rem;
+    }
+
+    > div {
+      margin-top: 1.5rem;
     }
   }
   ${media.portrait`

--- a/frontend/src/routes/ApplicationForm/index.tsx
+++ b/frontend/src/routes/ApplicationForm/index.tsx
@@ -10,6 +10,7 @@ import GroupApplication from "src/containers/GroupApplication";
 
 import FormStructure from "./FormStructure";
 import {
+  getApplictionTextDrafts,
   getPhoneNumberDraft,
   getPriorityTextDraft,
 } from "src/utils/draftHelper";
@@ -107,7 +108,7 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({
   const {
     text = getPriorityTextDraft(),
     phone_number: phoneNumber = getPhoneNumberDraft(),
-    group_applications: groupApplications = [],
+    group_applications: groupApplications = getApplictionTextDrafts(),
   } = myApplication || {};
 
   const blankGroupApplications: { [key: string]: string } = {};
@@ -115,13 +116,15 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({
     blankGroupApplications[group] = "";
   });
 
-  const reformattedGroupApplications = groupApplications.reduce(
-    (obj, application) => ({
-      ...obj,
-      [application.group.name.toLowerCase()]: application.text,
-    }),
-    {}
-  );
+  const reformattedGroupApplications = Array.isArray(groupApplications)
+    ? groupApplications.reduce(
+        (obj, application) => ({
+          ...obj,
+          [application.group.name.toLowerCase()]: application.text,
+        }),
+        {}
+      )
+    : groupApplications;
 
   const initialValues: FormValues = {
     priorityText: text,

--- a/frontend/src/routes/ApplicationPortal.tsx
+++ b/frontend/src/routes/ApplicationPortal.tsx
@@ -29,7 +29,9 @@ interface SelectedGroups {
 
 const ApplicationPortal = () => {
   const { admissionSlug } = useParams();
-  const [selectedGroups, setSelectedGroups] = useState<SelectedGroups>({});
+  const [selectedGroups, setSelectedGroups] = useState<SelectedGroups>(
+    getSelectedGroupsDraft()
+  );
   const [isEditingApplication, setIsEditingApplication] = useState<
     boolean | null
   >(null);
@@ -68,6 +70,14 @@ const ApplicationPortal = () => {
   useEffect(() => {
     initializeState();
   }, []);
+
+  useEffect(() => {
+    // Only run on first load after myApplication is set
+    if (isEditingApplication === null && myApplication !== undefined) {
+      // Set to is not editing if myApplication exists (user has submitted an application)
+      setIsEditingApplication(!myApplication);
+    }
+  }, [isEditingApplication, myApplication]);
 
   useEffect(() => {
     if (isFetching) return;

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -140,28 +140,11 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
           <SectionHeader>Generelt</SectionHeader>
           <HelpText>
             <Icon name="information-circle-outline" />
-            Mobilnummeret vil bli brukt til å kalle deg inn på intervju av
-            komitéledere.
+            Mobilnummeret vil bli brukt til å kalle deg inn på intervju.
           </HelpText>
           <Field
             name="phoneNumber"
             component={PhoneNumberField}
-            disabled={true}
-          />
-
-          <HelpText>
-            <Icon name="information-circle-outline" />
-            Kun leder av Abakus kan se det du skriver inn i prioriterings- og
-            kommentarfeltet.
-            <Icon name="information-circle-outline" />
-            Det er ikke sikkert prioriteringslisten vil bli tatt hensyn til.
-            Ikke søk på en komité du ikke ønsker å bli med i.
-          </HelpText>
-          <Field
-            name="priorityText"
-            component={PriorityTextField}
-            label="Prioriteringer, og andre kommentarer"
-            optional
             disabled={true}
           />
         </GeneralInfoSection>
@@ -174,6 +157,11 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
                 <Icon name="information-circle-outline" />
                 Her skriver du søknaden til komiteen(e) du har valgt. Hver
                 komité kan kun se søknaden til sin egen komité.
+              </HelpText>
+              <HelpText>
+                <Icon name="information-circle-outline" />
+                Søknadene vil brukes i opptaksprosessen, men alle søkere vil bli
+                kalt inn til intervju.
               </HelpText>
             </div>
           </Sidebar>

--- a/frontend/src/utils/draftHelper.ts
+++ b/frontend/src/utils/draftHelper.ts
@@ -38,7 +38,7 @@ export const saveApplicationTextDraft = ([groupName, applicationText]: [
   });
 };
 
-export const getApplictionTextDrafts = () =>
+export const getApplictionTextDrafts: () => Record<string, string> = () =>
   getParsedJson(KeyType.applicationText);
 
 interface SelectedGroupsDraft {


### PR DESCRIPTION
Changes

- Update text to match HS' wishes (specify usage of application texts and remove priority-field).
- Re-activeted application draft to make sure that it works (at least it now works on my end to reload the page and it stays the same)
- Fixed bug where you had to submit multiple times
- Set react-query to refetch as little as possible (the admission shouldn't update while it's being edited so there should be no need)

Currently I have made no changes to the admin-views or the backend - as the priority-text was never mandatory. Thus it now works as if all applicants left them blank, and the admins will see it as an empty box. If anyone wants to remove it from the admin-view as well that should be a quick fix.

Visual changes;

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td> 
<img width="811" alt="image" src="https://github.com/webkom/admissions/assets/13599770/327048be-1c1e-47b4-93cc-207efea2f9ae">

 <td> 
<img width="837" alt="image" src="https://github.com/webkom/admissions/assets/13599770/406a534d-658b-4cf9-befb-9739207f038c">

</table>

Resolves ABA-464, ABA-463