### PR TITLE
Use "gruppe" instead of "komite" in strings in revue admission

### DIFF
--- a/admissions/templates/index.html
+++ b/admissions/templates/index.html
@@ -9,7 +9,7 @@
     <meta name="theme-color" content="#000000">
     <meta property="og:url" content="{{ settings.FRONTEND_URL }}">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Søk komité!">
+    <meta property="og:title" content="Søk komité og revy!">
     <meta property="og:description" content="Vil du være med å bidra til at Abakus skal fortsette å være den beste linjeforeningen? Da må du søke komité! ">
     <meta property="og:image" content="{% static "og_logo.png" %}">
     <!--

--- a/frontend/src/components/GroupCard/index.tsx
+++ b/frontend/src/components/GroupCard/index.tsx
@@ -23,8 +23,8 @@ const GroupCard: React.FC<GroupCardProps> = ({
   isRevy,
 }) => {
   return (
-    <Card onClick={() => onToggle(name)} isChosen={isChosen}>
-      <Logo src={logo} />
+    <Card onClick={() => onToggle(name)} isChosen={isChosen} $isRevy={isRevy}>
+      {!isRevy && <Logo src={logo} />}
       <Name>{readmeIfy(name)}</Name>
       <Description>{readmeIfy(description, true)}</Description>
       <LearnMoreLink href={`${readMoreLink}`} target="_blank">
@@ -49,17 +49,19 @@ export default GroupCard;
 
 /** Styles **/
 
-interface GroupCardStyledProps {
+interface GroupCardElementsStyledProps {
   isChosen?: boolean;
 }
+
+type GroupCardStyledProps = GroupCardElementsStyledProps & { $isRevy: boolean };
 
 export const Card = styled.div<GroupCardStyledProps>`
   display: grid;
   grid-template-columns: 1fr 3fr;
-  grid-template-rows: 2rem 1fr 1.5rem;
+  grid-template-rows: 2rem 1fr ${({ $isRevy }) => !$isRevy && "1.5rem"};
   grid-template-areas:
-    ". name"
-    "logo text"
+    "${({ $isRevy }) => ($isRevy ? "name" : ".")} name"
+    "${({ $isRevy }) => ($isRevy ? "text" : "logo")} text"
     ". readmore";
   grid-gap: 10px 20px;
   background: var(--lego-white);
@@ -145,7 +147,7 @@ export const LearnMoreLink = styled.a`
     `};
 `;
 
-export const SelectedMark = styled.div<GroupCardStyledProps>`
+export const SelectedMark = styled.div<GroupCardElementsStyledProps>`
   width: 100%;
   height: 35px;
   padding: 8px 0;
@@ -162,7 +164,7 @@ export const SelectedMark = styled.div<GroupCardStyledProps>`
   border-radius: 0px 0px 10px 10px;
 `;
 
-const SelectedMarkText = styled.span<GroupCardStyledProps>`
+const SelectedMarkText = styled.span<GroupCardElementsStyledProps>`
   color: ${(props) =>
     props.isChosen ? "var(--lego-white);" : "var(--lego-gray-light);"};
   font-size: 1rem;

--- a/frontend/src/components/GroupCard/index.tsx
+++ b/frontend/src/components/GroupCard/index.tsx
@@ -10,6 +10,7 @@ interface GroupCardProps {
   description: string;
   readMoreLink: string;
   logo: string;
+  isRevy: boolean;
 }
 
 const GroupCard: React.FC<GroupCardProps> = ({
@@ -19,6 +20,7 @@ const GroupCard: React.FC<GroupCardProps> = ({
   description,
   readMoreLink,
   logo,
+  isRevy,
 }) => {
   return (
     <Card onClick={() => onToggle(name)} isChosen={isChosen}>
@@ -34,7 +36,9 @@ const GroupCard: React.FC<GroupCardProps> = ({
             Valgt <span>- klikk for å fjerne</span>
           </SelectedMarkText>
         ) : (
-          <SelectedMarkText>Velg komité</SelectedMarkText>
+          <SelectedMarkText>
+            Velg {isRevy ? "gruppe" : "komité"}
+          </SelectedMarkText>
         )}
       </SelectedMark>
     </Card>

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -16,6 +16,7 @@ interface NavBarProps {
 const NavBar: React.FC<NavBarProps> = ({ user, isEditing }) => {
   const { admissionSlug } = useParams();
   const { data: admission } = useAdmission(admissionSlug ?? "");
+  const isRevy = admissionSlug === "revy";
 
   return (
     <Container>
@@ -26,7 +27,7 @@ const NavBar: React.FC<NavBarProps> = ({ user, isEditing }) => {
         <NavItemsContainer>
           <NavItem
             to={`/${admissionSlug}/velg-komiteer`}
-            text="Velg komiteer"
+            text={isRevy ? "Velg grupper" : "Velg komiteer"}
           />
           <NavItem to={`/${admissionSlug}/min-soknad`} text="Min søknad" />
         </NavItemsContainer>

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -26,7 +26,7 @@ const NavBar: React.FC<NavBarProps> = ({ user, isEditing }) => {
       {!admission?.userdata.has_application || isEditing ? (
         <NavItemsContainer>
           <NavItem
-            to={`/${admissionSlug}/velg-komiteer`}
+            to={`/${admissionSlug}/velg-grupper`}
             text={isRevy ? "Velg grupper" : "Velg komiteer"}
           />
           <NavItem to={`/${admissionSlug}/min-soknad`} text="Min søknad" />

--- a/frontend/src/routes/ApplicationForm/FormStructure.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.tsx
@@ -3,7 +3,6 @@ import { Form, Field, FormikValues } from "formik";
 import FormatTime from "src/components/Time/FormatTime";
 import Icon from "src/components/Icon";
 import LegoButton from "src/components/LegoButton";
-import PriorityTextField from "./PriorityTextField";
 import PhoneNumberField from "./PhoneNumberField";
 import ToggleGroups from "./ToggleGroups";
 import ErrorFocus from "./ErrorFocus";
@@ -51,6 +50,7 @@ const FormStructure: React.FC<FormStructureProps> = ({
   onCancel,
 }) => {
   const { data: myApplication } = useMyApplication(String(admission.slug));
+  const isRevy = admission.slug === "revy";
 
   return (
     <PageWrapper>
@@ -84,11 +84,12 @@ const FormStructure: React.FC<FormStructureProps> = ({
         <GroupsSection>
           <Sidebar>
             <div>
-              <SectionHeader>Komiteer</SectionHeader>
+              <SectionHeader>{isRevy ? "Grupper" : "Komiteer"}</SectionHeader>
               <HelpText>
                 <Icon name="information-circle-outline" />
-                Her skriver du søknaden til komiteen(e) du har valgt. Hver
-                komité kan kun se søknaden til sin egen komité.
+                {isRevy
+                  ? "Her skriver du søknaden til gruppen(e) du har valgt."
+                  : "Her skriver du søknaden til komiteen(e) du har valgt. Hver komité kan kun se søknaden til sin egen komité."}
               </HelpText>
               <HelpText>
                 <Icon name="information-circle-outline" />
@@ -107,16 +108,19 @@ const FormStructure: React.FC<FormStructureProps> = ({
             <Applications>{SelectedGroupItems}</Applications>
           ) : (
             <NoChosenGroupsWrapper>
-              <NoChosenTitle>Du har ikke valgt noen komiteer.</NoChosenTitle>
+              <NoChosenTitle>
+                Du har ikke valgt noen {isRevy ? "grupper" : "komiteer"}.
+              </NoChosenTitle>
               <NoChosenSubTitle>
-                Velg i sidemargen eller gå til komiteoversikten
+                Velg i sidemargen eller gå til {isRevy ? "gruppe" : "komite"}
+                oversikten
               </NoChosenSubTitle>
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
                 to={`/${admission.slug}/velg-komiteer`}
               >
-                Velg komiteer
+                Velg {isRevy ? "grupper" : "komiteer"}
               </LegoButton>
             </NoChosenGroupsWrapper>
           )}
@@ -144,12 +148,13 @@ const FormStructure: React.FC<FormStructureProps> = ({
             )}
             <SubmitInfo>
               Oppdateringer etter søknadsfristen kan ikke garanteres å bli sett
-              av komiteen(e) du søker deg til.
+              {!isRevy && " av komiteen(e) du søker deg til"}.
             </SubmitInfo>
             <SubmitInfo>
-              Din søknad til hver komité kan kun ses av den aktuelle komiteen og
-              leder av Abakus. All søknadsinformasjon slettes etter opptaket er
-              gjennomført.
+              {isRevy
+                ? "Søknaden din kan kun ses av revystyret."
+                : "Din søknad til hver komité kan kun ses av den aktuelle komiteen og leder av Abakus."}{" "}
+              All søknadsinformasjon slettes etter opptaket er gjennomført.
             </SubmitInfo>
             <SubmitInfo>Du kan når som helst trekke søknaden din.</SubmitInfo>
           </div>

--- a/frontend/src/routes/ApplicationForm/FormStructure.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.tsx
@@ -97,11 +97,13 @@ const FormStructure: React.FC<FormStructureProps> = ({
                 kalt inn til intervju.
               </HelpText>
 
-              <ToggleGroups
-                groups={groups}
-                selectedGroups={selectedGroups}
-                toggleGroup={toggleGroup}
-              />
+              {!isRevy && (
+                <ToggleGroups
+                  groups={groups}
+                  selectedGroups={selectedGroups}
+                  toggleGroup={toggleGroup}
+                />
+              )}
             </div>
           </Sidebar>
           {hasSelected ? (
@@ -118,7 +120,7 @@ const FormStructure: React.FC<FormStructureProps> = ({
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to={`/${admission.slug}/velg-komiteer`}
+                to={`/${admission.slug}/velg-grupper`}
               >
                 Velg {isRevy ? "grupper" : "komiteer"}
               </LegoButton>

--- a/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
+++ b/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
@@ -44,7 +44,7 @@ const ToggleGroups: React.FC<ToggleGroupsProps> = ({
         til/fjerne dem fra søknaden.
       </Tooltip>
       <IconsWrapper>{ChooseGroupsItems}</IconsWrapper>
-      <LinkToOverview to={`/${admissionSlug}/velg-komiteer`}>
+      <LinkToOverview to={`/${admissionSlug}/velg-grupper`}>
         Eller gå tilbake til oversikten for å lese mer
       </LinkToOverview>
     </Wrapper>

--- a/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
+++ b/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
@@ -24,6 +24,7 @@ const ToggleGroups: React.FC<ToggleGroupsProps> = ({
   toggleGroup,
 }) => {
   const { admissionSlug } = useParams();
+  const isRevy = admissionSlug === "revy";
 
   const ChooseGroupsItems = groups.map((group, index) => (
     <MiniToggleGroup
@@ -39,7 +40,8 @@ const ToggleGroups: React.FC<ToggleGroupsProps> = ({
     <Wrapper>
       <Title>Endre dine valg</Title>
       <Tooltip>
-        Klikk på logoene til komiteene for å legge til/fjerne de fra søknaden.
+        Klikk på logoene til {isRevy ? "gruppene" : "komiteene"} for å legge
+        til/fjerne dem fra søknaden.
       </Tooltip>
       <IconsWrapper>{ChooseGroupsItems}</IconsWrapper>
       <LinkToOverview to={`/${admissionSlug}/velg-komiteer`}>

--- a/frontend/src/routes/ApplicationPortal.tsx
+++ b/frontend/src/routes/ApplicationPortal.tsx
@@ -116,7 +116,7 @@ const ApplicationPortal = () => {
         <ContentContainer>
           <Routes>
             <Route
-              path="/velg-komiteer"
+              path="/velg-grupper"
               element={
                 <GroupsPage
                   toggleGroup={toggleGroup}

--- a/frontend/src/routes/GroupsPage/index.tsx
+++ b/frontend/src/routes/GroupsPage/index.tsx
@@ -20,6 +20,8 @@ const GroupsPage: React.FC<GroupsPageProps> = ({
   const { data: admission } = useAdmission(admissionSlug ?? "");
   const { groups } = admission ?? {};
 
+  const isRevy = admissionSlug === "revy";
+
   const handleToggleGroup = (name: string) => {
     toggleGroup(name.toLowerCase());
   };
@@ -35,6 +37,7 @@ const GroupsPage: React.FC<GroupsPageProps> = ({
       onToggle={handleToggleGroup}
       isChosen={!!selectedGroups[group.name.toLowerCase()]}
       readMoreLink={group.detail_link}
+      isRevy={isRevy}
     />
   ));
 
@@ -44,7 +47,9 @@ const GroupsPage: React.FC<GroupsPageProps> = ({
 
   return (
     <PageWrapper>
-      <Title>Velg de komiteene du vil søke på og gå videre</Title>
+      <Title>
+        Velg de {isRevy ? "gruppene" : "komiteene"} du vil søke på og gå videre
+      </Title>
       <GroupsWrapper>{GroupCards}</GroupsWrapper>
       <NextButtonWrapper>
         <LegoButton
@@ -58,7 +63,8 @@ const GroupsPage: React.FC<GroupsPageProps> = ({
         {!hasSelectedAnything() && (
           <ErrorMessage>
             <Icon name="information-circle-outline" />
-            Du må velge en eller flere komiteer før du kan gå videre
+            Du må velge en eller flere {isRevy ? "grupper" : "komiteer"} før du
+            kan gå videre
           </ErrorMessage>
         )}
       </NextButtonWrapper>

--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -12,6 +12,8 @@ interface AdmissionProps {
 }
 
 const Admission: React.FC<AdmissionProps> = ({ admission }) => {
+  const isRevy = admission.slug === "revy";
+
   return (
     <AdmissionWrapper>
       <AdmissionDetails>
@@ -76,7 +78,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
                       `/${admission.slug}/` +
                       (admission.userdata.has_application
                         ? "min-soknad"
-                        : "velg-komiteer")
+                        : "velg-grupper")
                     }
                     icon="arrow-forward"
                     iconPrefix="ios"
@@ -118,7 +120,12 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
       <p>
         Du kan til enhver tid trekke søknaden din hvis du skulle ombestemme deg.
         Hvis det ikke fungerer å slette søknaden, send en mail til{" "}
-        <a href="mailto:leder@abakus.no">leder@abakus.no</a>.
+        {isRevy ? (
+          <a href="mailto:revy@abakus.no">revy@abakus.no</a>
+        ) : (
+          <a href="mailto:leder@abakus.no">leder@abakus.no</a>
+        )}
+        .
       </p>
     </AdmissionWrapper>
   );

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -5,7 +5,6 @@ import Icon from "src/components/Icon";
 import LegoButton from "src/components/LegoButton";
 import ConfirmModal from "src/components/ConfirmModal";
 import Application from "src/containers/GroupApplication/Application";
-import PriorityTextField from "src/routes/ApplicationForm/PriorityTextField";
 import PhoneNumberField from "src/routes/ApplicationForm/PhoneNumberField";
 import { useAdmission, useMyApplication } from "src/query/hooks";
 import { useDeleteMyApplicationMutation } from "src/query/mutations";
@@ -42,6 +41,7 @@ interface FormStructureProps {
 
 const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
   const { admissionSlug } = useParams();
+  const isRevy = admissionSlug === "revy";
   const navigate = useNavigate();
   const deleteApplicationMutation = useDeleteMyApplicationMutation(
     admissionSlug ?? ""
@@ -86,12 +86,13 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
                   </FormatTime>
                 </StyledSpan>
               )}{" "}
-              og komiteene vil kun se den siste versjonen.
+              og {isRevy ? "revystyret" : "komiteene"} vil kun se den siste
+              versjonen.
             </Text>
             <Notice>
               <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter
-              søknadsfristen kan ikke garanteres å bli sett av komiteen(e) du
-              søker deg til.
+              søknadsfristen kan ikke garanteres å bli sett av{" "}
+              {isRevy ? "revystyret" : "komiteen(e) du søker deg til"}.
             </Notice>
           </EditInfo>
           <EditActions>
@@ -152,11 +153,13 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
         <GroupsSection>
           <Sidebar>
             <div>
-              <SectionHeader>Komiteer</SectionHeader>
+              <SectionHeader>{isRevy ? "Grupper" : "Komiteer"}</SectionHeader>
               <HelpText>
                 <Icon name="information-circle-outline" />
-                Her skriver du søknaden til komiteen(e) du har valgt. Hver
-                komité kan kun se søknaden til sin egen komité.
+                Her skriver du søknaden til{" "}
+                {isRevy ? "gruppen(e)" : "komiteen(e)"} du har valgt.
+                {!isRevy &&
+                  "Hver komité kan kun se søknaden til sin egen komité."}
               </HelpText>
               <HelpText>
                 <Icon name="information-circle-outline" />
@@ -187,16 +190,19 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
             </Applications>
           ) : (
             <NoChosenGroupsWrapper>
-              <NoChosenTitle>Du har ikke valgt noen komiteer.</NoChosenTitle>
+              <NoChosenTitle>
+                Du har ikke valgt noen {isRevy ? "grupper" : "komiteer"}.
+              </NoChosenTitle>
               <NoChosenSubTitle>
-                Send inn en ny søknad for å velge komitéer.
+                Send inn en ny søknad for å velge{" "}
+                {isRevy ? "grupper" : "komiteer"}.
               </NoChosenSubTitle>
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
                 to={`/${admissionSlug}/velg-komiteer`}
               >
-                Velg komiteer
+                Velg {isRevy ? "grupper" : "komiteer"}
               </LegoButton>
             </NoChosenGroupsWrapper>
           )}

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -200,7 +200,7 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to={`/${admissionSlug}/velg-komiteer`}
+                to={`/${admissionSlug}/velg-grupper`}
               >
                 Velg {isRevy ? "grupper" : "komiteer"}
               </LegoButton>


### PR DESCRIPTION
Tons of text-strings say "komite" throughout the webapp. This is a quick and easy fix to make it work for the admission on monday by replacing "komite" with "gruppe" if the slug is "revy".
Also removes some text saying only the relevant group can read the application, as I believe the entire revue board can read all applications.