### PR TITLE
Remove further ocurrences of committee and remove images

### DIFF
--- a/frontend/src/components/GroupCard/index.tsx
+++ b/frontend/src/components/GroupCard/index.tsx
@@ -23,8 +23,8 @@ const GroupCard: React.FC<GroupCardProps> = ({
   isRevy,
 }) => {
   return (
-    <Card onClick={() => onToggle(name)} isChosen={isChosen}>
-      <Logo src={logo} />
+    <Card onClick={() => onToggle(name)} isChosen={isChosen} $isRevy={isRevy}>
+      {!isRevy && <Logo src={logo} />}
       <Name>{readmeIfy(name)}</Name>
       <Description>{readmeIfy(description, true)}</Description>
       <LearnMoreLink href={`${readMoreLink}`} target="_blank">
@@ -49,17 +49,19 @@ export default GroupCard;
 
 /** Styles **/
 
-interface GroupCardStyledProps {
+interface GroupCardElementsStyledProps {
   isChosen?: boolean;
 }
+
+type GroupCardStyledProps = GroupCardElementsStyledProps & { $isRevy: boolean };
 
 export const Card = styled.div<GroupCardStyledProps>`
   display: grid;
   grid-template-columns: 1fr 3fr;
-  grid-template-rows: 2rem 1fr 1.5rem;
+  grid-template-rows: 2rem 1fr ${({ $isRevy }) => !$isRevy && "1.5rem"};
   grid-template-areas:
-    ". name"
-    "logo text"
+    "${({ $isRevy }) => ($isRevy ? "name" : ".")} name"
+    "${({ $isRevy }) => ($isRevy ? "text" : "logo")} text"
     ". readmore";
   grid-gap: 10px 20px;
   background: var(--lego-white);
@@ -145,7 +147,7 @@ export const LearnMoreLink = styled.a`
     `};
 `;
 
-export const SelectedMark = styled.div<GroupCardStyledProps>`
+export const SelectedMark = styled.div<GroupCardElementsStyledProps>`
   width: 100%;
   height: 35px;
   padding: 8px 0;
@@ -162,7 +164,7 @@ export const SelectedMark = styled.div<GroupCardStyledProps>`
   border-radius: 0px 0px 10px 10px;
 `;
 
-const SelectedMarkText = styled.span<GroupCardStyledProps>`
+const SelectedMarkText = styled.span<GroupCardElementsStyledProps>`
   color: ${(props) =>
     props.isChosen ? "var(--lego-white);" : "var(--lego-gray-light);"};
   font-size: 1rem;

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -26,7 +26,7 @@ const NavBar: React.FC<NavBarProps> = ({ user, isEditing }) => {
       {!admission?.userdata.has_application || isEditing ? (
         <NavItemsContainer>
           <NavItem
-            to={`/${admissionSlug}/velg-komiteer`}
+            to={`/${admissionSlug}/velg-grupper`}
             text={isRevy ? "Velg grupper" : "Velg komiteer"}
           />
           <NavItem to={`/${admissionSlug}/min-soknad`} text="Min søknad" />

--- a/frontend/src/routes/ApplicationForm/FormStructure.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.tsx
@@ -97,11 +97,13 @@ const FormStructure: React.FC<FormStructureProps> = ({
                 kalt inn til intervju.
               </HelpText>
 
-              <ToggleGroups
-                groups={groups}
-                selectedGroups={selectedGroups}
-                toggleGroup={toggleGroup}
-              />
+              {!isRevy && (
+                <ToggleGroups
+                  groups={groups}
+                  selectedGroups={selectedGroups}
+                  toggleGroup={toggleGroup}
+                />
+              )}
             </div>
           </Sidebar>
           {hasSelected ? (
@@ -118,7 +120,7 @@ const FormStructure: React.FC<FormStructureProps> = ({
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to={`/${admission.slug}/velg-komiteer`}
+                to={`/${admission.slug}/velg-grupper`}
               >
                 Velg {isRevy ? "grupper" : "komiteer"}
               </LegoButton>

--- a/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
+++ b/frontend/src/routes/ApplicationForm/ToggleGroups.tsx
@@ -44,7 +44,7 @@ const ToggleGroups: React.FC<ToggleGroupsProps> = ({
         til/fjerne dem fra søknaden.
       </Tooltip>
       <IconsWrapper>{ChooseGroupsItems}</IconsWrapper>
-      <LinkToOverview to={`/${admissionSlug}/velg-komiteer`}>
+      <LinkToOverview to={`/${admissionSlug}/velg-grupper`}>
         Eller gå tilbake til oversikten for å lese mer
       </LinkToOverview>
     </Wrapper>

--- a/frontend/src/routes/ApplicationPortal.tsx
+++ b/frontend/src/routes/ApplicationPortal.tsx
@@ -116,7 +116,7 @@ const ApplicationPortal = () => {
         <ContentContainer>
           <Routes>
             <Route
-              path="/velg-komiteer"
+              path="/velg-grupper"
               element={
                 <GroupsPage
                   toggleGroup={toggleGroup}

--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -12,6 +12,8 @@ interface AdmissionProps {
 }
 
 const Admission: React.FC<AdmissionProps> = ({ admission }) => {
+  const isRevy = admission.slug === "revy";
+
   return (
     <AdmissionWrapper>
       <AdmissionDetails>
@@ -76,7 +78,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
                       `/${admission.slug}/` +
                       (admission.userdata.has_application
                         ? "min-soknad"
-                        : "velg-komiteer")
+                        : "velg-grupper")
                     }
                     icon="arrow-forward"
                     iconPrefix="ios"
@@ -118,7 +120,12 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
       <p>
         Du kan til enhver tid trekke søknaden din hvis du skulle ombestemme deg.
         Hvis det ikke fungerer å slette søknaden, send en mail til{" "}
-        <a href="mailto:leder@abakus.no">leder@abakus.no</a>.
+        {isRevy ? (
+          <a href="mailto:revy@abakus.no">revy@abakus.no</a>
+        ) : (
+          <a href="mailto:leder@abakus.no">leder@abakus.no</a>
+        )}
+        .
       </p>
     </AdmissionWrapper>
   );

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -200,7 +200,7 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to={`/${admissionSlug}/velg-komiteer`}
+                to={`/${admissionSlug}/velg-grupper`}
               >
                 Velg {isRevy ? "grupper" : "komiteer"}
               </LegoButton>


### PR DESCRIPTION
Update path from /velg-komiteer to /velg-grupper.
Add revy email as contact email.
Remove logos and logo-selector.

Lastly, it can be considered if the "Les mer på abakus.no" text for each group should be changed to https://abakus.no/pages/grupper/104-revyen, or each individual group page.  
I recommend to send it to https://abakus.no/pages/grupper/104-revyen, but then a bit of info on that page has to be updated (names of persons and info about the admission).  
If linking to each individual group is desirable, past members might need to be removed from their groups..

Aaaand another sidenote, in https://abakus.no/pages/grupper/104-revyen, it is stated that the priorization field could be filled out. If they want to have that we might want to re-add the field for the revue admission. If not the infopage should be updated to reflect that the field no longer exists.


I'm not able to check in on this all the time, so if you approve, **please merge and deploy it for me**(: