### PR TITLE
Update admission queryset to be admission-specific

### DIFF
--- a/admissions/admissions/constants.py
+++ b/admissions/admissions/constants.py
@@ -53,9 +53,7 @@ KOMTEK_LONG = "Kommunikasjonsteknologi"
 COURSES_LONG = ((DATA_LONG, DATA_LONG), (KOMTEK_LONG, KOMTEK_LONG))
 
 # Groups that give privileges to their leaders
-SUPERUSER_LEADER_GROUPS = ["Hovedstyret", "RevyStyret"]
-""" Members of this group with role leader should attain the is_superuser attribute """
 STAFF_LEADER_GROUPS = ["backup", "Hovedstyret", "RevyStyret"]
-""" Members of this group with role leader should attain the is_staff attribute """
+""" Members of this group with role leader should attain the is_staff attribute and be able to manage admissions """
 WEBKOM_GROUPNAME = "Webkom"
 """ Group name of Webkom """

--- a/admissions/admissions/models.py
+++ b/admissions/admissions/models.py
@@ -12,24 +12,6 @@ class LegoUser(AbstractUser):
     profile_picture = models.URLField(null=True, blank=True)
 
     @property
-    def is_privileged(self):
-        """
-        Return true if the user is Abakus Leader or has admission privileges
-        """
-        return bool(self.is_superuser or self.admission_privileges)
-
-    @property
-    def admission_privileges(self):
-        """
-        Return true if the user has the role of LEADER or RECRUTING
-        """
-        return (
-            Membership.objects.filter(user=self)
-            .filter(Q(role=constants.LEADER) | Q(role=constants.RECRUITING))
-            .exists()
-        )
-
-    @property
     def representative_of_group(self):
         """
         Return the name of the group this user is the representative for

--- a/admissions/oauth.py
+++ b/admissions/oauth.py
@@ -126,17 +126,8 @@ def update_custom_user_details(strategy, details, user=None, *args, **kwargs):
     with transaction.atomic():
         # Remove old memberships before creating the new ones
         Membership.objects.filter(user=user).delete()
-        user.is_superuser = False
         for group, membership in group_data:
-            # This check finds the leader of Abakus by looking at the group leader
-            # of Hovedstyret. This is the only superuser of this application.
-            if (
-                group["name"] in constants.SUPERUSER_LEADER_GROUPS
-                and membership["role"] == constants.LEADER
-            ):
-                user.is_superuser = True
-
-            # Leaders of certain groups have staff_permission, which allows them to edit admissions
+            # Leaders of certain groups have staff_permission, which allows them to manage admissions
             if (
                 group["name"] in constants.STAFF_LEADER_GROUPS
                 and membership["role"] == constants.LEADER

--- a/admissions/templates/index.html
+++ b/admissions/templates/index.html
@@ -38,8 +38,6 @@
       user: {
         profile_picture: "{{ request.user.profile_picture|default:'' }}",
         full_name: "{{ request.user.get_full_name }}",
-        is_superuser: {{ request.user.is_superuser|yesno:"true,false" }},
-        is_privileged: {{ request.user.is_privileged|yesno:"true,false" }},
         representative_of_group: "{{ request.user.representative_of_group }}",
         is_staff: {{ request.user.is_staff|yesno:"true,false" }},
         is_member_of_webkom: {{ request.user.is_member_of_webkom|yesno:"true,false" }}


### PR DESCRIPTION
Makes the application list not care about is_staff and is_superuser, but rather the memberships in the groups pertaining the the admission.

The code that deletes applications still uses is_staff and is_superuser, but you could copy the same logic in that part if that's important..