### PR TITLE
Prevent unauthorized users from trying to load non-root pages

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,6 +35,7 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       queryFn: defaultQueryFn,
       staleTime: 60000,
+      retry: false,
     },
   },
 });
@@ -68,7 +69,14 @@ const AppRoutes = () =>
         </RequireAuth>
       ),
     },
-    { path: ":admissionSlug/*", element: <ApplicationPortal /> },
+    {
+      path: ":admissionSlug/*",
+      element: (
+        <RequireAuth auth={!!djangoData.user.full_name}>
+          <ApplicationPortal />
+        </RequireAuth>
+      ),
+    },
     { path: "*", element: <NotFoundPage /> },
   ]);
 


### PR DESCRIPTION
It looked like the page loaded forever, because react-query by default will retry 3 times to load the resource before admitting defeat. This seems a bit unnecessary for this page, so I disabled.

And unauthorized users could previously view the admission page - but not apply - so there was no real reason to view it.

Resolves ABA-475