### PR TITLE
Allow deletion of admissions from GUI

### DIFF
--- a/admissions/admissions/models.py
+++ b/admissions/admissions/models.py
@@ -30,7 +30,11 @@ class LegoUser(AbstractUser):
         """
         Return whether the user is a member of the webkom-group or not
         """
-        webkom = Group.objects.get(name=constants.WEBKOM_GROUPNAME)
+        try:
+            webkom = Group.objects.get(name=constants.WEBKOM_GROUPNAME)
+        except Group.DoesNotExist:
+            # Allow the project to run without a group named "webkom" initialized
+            return False
         return Membership.objects.filter(user=self, group=webkom).exists()
 
 

--- a/admissions/admissions/tests/test_admin_admission_delete.py
+++ b/admissions/admissions/tests/test_admin_admission_delete.py
@@ -1,0 +1,212 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from admissions.admissions.constants import MEMBER
+from admissions.admissions.models import (
+    Admission,
+    Group,
+    GroupApplication,
+    LegoUser,
+    Membership,
+    UserApplication,
+)
+from admissions.admissions.tests.utils import create_admission, fake_timedelta
+
+
+class DeleteAdmissionAuthorizationTestCase(APITestCase):
+    """
+    Test that only the designated users can delete an admission
+    """
+
+    def setUp(self) -> None:
+        yesterday = fake_timedelta(-1)
+        self.admission = create_admission(closed_from=yesterday)
+
+    def test_webkom_can_delete_admission(self):
+        webkom_user = LegoUser.objects.create(username="webkom_member")
+        webkom = Group.objects.create(
+            name="Webkom",
+            description="Webkom styrer tekniske ting",
+            response_label="Søk Webkom fordi du lærer deg nyttige ting!",
+        )
+        Membership.objects.create(user=webkom_user, role=MEMBER, group=webkom)
+        self.client.force_authenticate(user=webkom_user)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+        self.assertTrue(
+            webkom_user.is_member_of_webkom,
+            "The authenticated user was supposed to be a member of webkom",
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertEqual(
+            Admission.objects.count(), 0, "The admission did not get deleted"
+        )
+
+    def test_staff_creator_can_delete_admission(self):
+        self.admission.created_by.is_staff = True
+        self.admission.created_by.save()
+        self.client.force_authenticate(user=self.admission.created_by)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertEqual(
+            Admission.objects.count(), 0, "The admission did not get deleted"
+        )
+
+    def test_staff_noncreator_cannot_delete_admission(self):
+        staff_user = LegoUser.objects.create(username="staff", is_staff=True)
+        self.client.force_authenticate(user=staff_user)
+
+        self.assertNotEqual(
+            staff_user.username,
+            self.admission.created_by.username,
+            "Authorized user did not create the admission",
+        )
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(Admission.objects.count(), 1, "The admission still exists")
+
+    def test_nonstaff_creator_cannot_delete_admission(self):
+        self.client.force_authenticate(user=self.admission.created_by)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.assertEqual(Admission.objects.count(), 1, "The admission got deleted")
+
+    def test_pleb_cannot_delete_admission(self):
+        pleb = LegoUser.objects.create(username="pleb")
+        self.client.force_authenticate(user=pleb)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.assertEqual(Admission.objects.count(), 1, "The admission still exists")
+
+
+class DeleteAdmissionValidityTestCase(APITestCase):
+    """
+    Test that the state of the admission allows deletion
+    """
+
+    def setUp(self) -> None:
+        tomorrow = fake_timedelta(1)
+        self.admission = create_admission(closed_from=tomorrow)
+        self.admission.created_by.is_staff = True
+        self.admission.created_by.save()
+
+    def test_unclosed_admission_cannot_be_deleted(self):
+        self.client.force_authenticate(user=self.admission.created_by)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "The admission was not supposed be deleted"
+        )
+
+
+class DeleteAdmissionCompleteTestCase(APITestCase):
+    """
+    Test that all data pertaining to the admission has in fact been deleted
+    """
+
+    def setUp(self) -> None:
+        # Create an admission and user that should be possible to delete
+        yesterday = fake_timedelta(-1)
+        self.admission = create_admission(closed_from=yesterday)
+        self.admission.created_by.is_staff = True
+        self.admission.created_by.save()
+
+        self.pleb = LegoUser.objects.create()
+
+        self.user_application = UserApplication.objects.create(
+            admission=self.admission,
+            user=self.pleb,
+            text="Jeg søker til dette opptaket fordi det er dritkult og sånn, prioritering er ikke så farlig",
+            phone_number="004712345678",
+        )
+
+        self.group = Group.objects.create(name="Testgruppe")
+
+        GroupApplication.objects.create(
+            application=self.user_application,
+            group=self.group,
+            text="Jeg synes denne gruppa virker dritkul så plis la meg komme på intervju",
+        )
+
+    def test_all_admission_data_is_deleted(self):
+        self.client.force_authenticate(user=self.admission.created_by)
+
+        self.assertEqual(
+            Admission.objects.count(), 1, "Only 1 admission was supposed to exist"
+        )
+        self.assertEqual(
+            UserApplication.objects.count(),
+            1,
+            "Only 1 user application was supposed to exist",
+        )
+        self.assertEqual(
+            GroupApplication.objects.count(),
+            1,
+            "Only 1 group application was supposed to exist",
+        )
+        self.assertEqual(
+            LegoUser.objects.count(), 2, "Only 2 users were supposed to exist"
+        )
+
+        res = self.client.delete(
+            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+        )
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertEqual(Admission.objects.count(), 0, "The admission was not deleted")
+        self.assertEqual(
+            UserApplication.objects.count(), 0, "There are still user application(s)"
+        )
+        self.assertEqual(
+            GroupApplication.objects.count(), 0, "There are still grup application(s)"
+        )
+        self.assertEqual(
+            LegoUser.objects.count(), 2, "The amount of users has been changed"
+        )

--- a/admissions/admissions/tests/test_api.py
+++ b/admissions/admissions/tests/test_api.py
@@ -1,46 +1,20 @@
-from datetime import timedelta
-
 from django.urls import reverse
-from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from admissions.admissions.constants import LEADER, MEMBER, RECRUITING
 from admissions.admissions.models import (
-    Admission,
     Group,
     GroupApplication,
     LegoUser,
     Membership,
     UserApplication,
 )
-
-admission_slug = "opptak"
-
-
-def fake_timedelta(days=0):
-    base_date = timezone.now().replace(hour=12, minute=15, second=0, microsecond=0)
-
-    return base_date + timedelta(days=days)
-
-
-def create_admission():
-    global admission_slug
-    base_date = timezone.now().replace(hour=23, minute=59, second=59, microsecond=59)
-
-    open_date = base_date.replace(
-        hour=12, minute=15, second=0, microsecond=0
-    ) - timedelta(days=1)
-    public_deadline_date = base_date + timedelta(days=7)
-    closed_from_date = base_date + timedelta(days=9)
-
-    return Admission.objects.create(
-        slug=admission_slug,
-        title=f"Opptak {base_date.year}",
-        open_from=open_date,
-        public_deadline=public_deadline_date,
-        closed_from=closed_from_date,
-    )
+from admissions.admissions.tests.utils import (
+    DEFAULT_ADMISSION_SLUG,
+    create_admission,
+    fake_timedelta,
+)
 
 
 class EditGroupTestCase(APITestCase):
@@ -199,8 +173,8 @@ class EditAdmissionTestCase(APITestCase):
 
 class CreateApplicationTestCase(APITestCase):
     def setUp(self):
-        global admission_slug
-        self.admission_slug = admission_slug
+        global DEFAULT_ADMISSION_SLUG
+        self.admission_slug = DEFAULT_ADMISSION_SLUG
         # Create admission and group
         self.admission = create_admission()
         self.webkom = Group.objects.create(name="Webkom")
@@ -296,8 +270,8 @@ class CreateApplicationTestCase(APITestCase):
 
 class ListApplicationsTestCase(APITestCase):
     def setUp(self):
-        global admission_slug
-        self.admission_slug = admission_slug
+        global DEFAULT_ADMISSION_SLUG
+        self.admission_slug = DEFAULT_ADMISSION_SLUG
 
         self.pleb = LegoUser.objects.create()
         leader_group = Group.objects.create(name="Abakus-Leder")
@@ -554,8 +528,8 @@ class DeleteGroupApplicationsTestCase(APITestCase):
     """
 
     def setUp(self):
-        global admission_slug
-        self.admission_slug = admission_slug
+        global DEFAULT_ADMISSION_SLUG
+        self.admission_slug = DEFAULT_ADMISSION_SLUG
         self.admission = create_admission()
 
         self.webkom_leader = LegoUser.objects.create(username="webkomleader")

--- a/admissions/admissions/tests/utils.py
+++ b/admissions/admissions/tests/utils.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from admissions.admissions.models import Admission, LegoUser
+
+DEFAULT_ADMISSION_SLUG = "opptak"
+
+
+def fake_timedelta(days=0):
+    base_date = timezone.now().replace(hour=12, minute=15, second=0, microsecond=0)
+
+    return base_date + timedelta(days=days)
+
+
+def create_admission(
+    created_by=None,
+    slug=None,
+    title=None,
+    open_from=None,
+    public_deadline=None,
+    closed_from=None,
+):
+    global DEFAULT_ADMISSION_SLUG
+
+    if created_by is None:
+        created_by = LegoUser.objects.create(username="creator")
+
+    if slug is None:
+        slug = DEFAULT_ADMISSION_SLUG
+
+    base_date = timezone.now().replace(hour=23, minute=59, second=59, microsecond=59)
+
+    if title is None:
+        title = f"Opptak {base_date.year}"
+
+    if open_from is None:
+        open_from = base_date.replace(
+            hour=12, minute=15, second=0, microsecond=0
+        ) - timedelta(days=1)
+
+    if public_deadline is None:
+        public_deadline = base_date + timedelta(days=7)
+
+    if closed_from is None:
+        closed_from = base_date + timedelta(days=9)
+
+    return Admission.objects.create(
+        created_by=created_by,
+        slug=slug,
+        title=title,
+        open_from=open_from,
+        public_deadline=public_deadline,
+        closed_from=closed_from,
+    )

--- a/admissions/utils/management/commands/create_admission.py
+++ b/admissions/utils/management/commands/create_admission.py
@@ -25,13 +25,12 @@ class Command(BaseCommand):
 
         admission = Admission.objects.create(
             title=f"Opptak {base_date.year}",
+            slug=f"opptak-{base_date.year}",
             open_from=open_date,
             public_deadline=public_deadline_date,
             closed_from=closed_from_date,
         )
 
-        groups = Group.objects.all()
-        for group in groups:
-            group.admissions.add(admission)
+        admission.groups.set(Group.objects.all())
 
         self.stdout.write(self.style.SUCCESS("Successfully created admission"))

--- a/frontend/src/components/ConfirmModal/index.tsx
+++ b/frontend/src/components/ConfirmModal/index.tsx
@@ -18,6 +18,8 @@ interface ConfirmModalProps {
   title: string;
   message: string;
   Component?: JSXElementConstructor<SubComponentProps>;
+  cancelText?: string;
+  confirmText?: string;
 }
 
 const ConfirmModal: React.FC<ConfirmModalProps> = ({
@@ -25,6 +27,8 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   title,
   message,
   Component,
+  cancelText = "Avbryt",
+  confirmText = "Ja",
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -52,9 +56,9 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
             border="1px solid darkgray"
             onClick={hideModal}
           >
-            Avbryt
+            {cancelText}
           </ActionButton>
-          <ActionButton onClick={confirmAction}>Ja</ActionButton>
+          <ActionButton onClick={confirmAction}>{confirmText}</ActionButton>
         </ButtonGroup>
       </ConfirmBox>
     </Overlay>

--- a/frontend/src/query/mutations.ts
+++ b/frontend/src/query/mutations.ts
@@ -29,7 +29,7 @@ export const useAdminCreateAdmission = () => {
     AxiosError,
     CreateAdmissionProps
   >(
-    async ({ admission }: CreateAdmissionProps) =>
+    async ({ admission }) =>
       (await apiClient.post("/admin/admission/", admission)).data,
     {
       onSuccess: () => {
@@ -50,8 +50,30 @@ export const useAdminUpdateAdmission = () => {
     AxiosError,
     UpdateAdmissionProps
   >(
-    async ({ slug, admission }: UpdateAdmissionProps) =>
+    async ({ slug, admission }) =>
       (await apiClient.patch(`/admin/admission/${slug}/`, admission)).data,
+    {
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries([`/admin/admission/`]);
+        queryClient.invalidateQueries([`/admin/admission/${variables.slug}/`]);
+      },
+    }
+  );
+};
+
+interface DeleteAdmissionProps {
+  slug: string;
+}
+
+export const useAdminDeleteAdmission = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    AdmissionMutationResponse,
+    AxiosError,
+    DeleteAdmissionProps
+  >(
+    async ({ slug }) =>
+      (await apiClient.delete(`/admin/admission/${slug}/`)).data,
     {
       onSuccess: (_, variables) => {
         queryClient.invalidateQueries([`/admin/admission/`]);


### PR DESCRIPTION
Admissions can be deleted by any member of Webkom or by the creator of the admission if the creator is staff (revue boss, hs big boss, backup boss) AFTER the admission has closed. (aka the same people that have permission to edit the admission)

Changes;
* Write tests to cover deletion
* Add button in admin "manage admission" view
* Add backend functionality to delete

Minor stuff that bugged me along the way;
* Admissions created using `python manage.py create_admission` were missing slugs, now they don't
* The modal component had no way to customize the action buttons, now it does

Before;
<img width="251" alt="image" src="https://github.com/webkom/admissions/assets/13599770/8141b56d-ea9a-4416-b983-6a616d3f6165">

After;

When it's not possible to delete it
<img width="386" alt="image" src="https://github.com/webkom/admissions/assets/13599770/7c4fcd9e-5491-4635-be87-7b7bccea8213">

When it is possible
<img width="393" alt="image" src="https://github.com/webkom/admissions/assets/13599770/2c1046ad-1bd3-46a3-a3d1-31965a862cfc">

Confirmation dialog
<img width="502" alt="image" src="https://github.com/webkom/admissions/assets/13599770/f87eab4c-cbca-407d-bf8c-049bc81d19c6">

Resolves ABA-410