### PR TITLE
json-fields step 2: store and display header_fields

### DIFF
--- a/admissions/admissions/tests/test_api.py
+++ b/admissions/admissions/tests/test_api.py
@@ -185,11 +185,12 @@ class CreateApplicationTestCase(APITestCase):
 
         self.application_data = {
             "text": "Ønsker Webkom mest",
+            "phone_number": "12345678",
+            "header_fields_response": {},
             "applications": {
                 "webkom": "Hohohohohohohohohohooho webbis",
                 "koskom": "Hahahahahahahahahahaha arris",
             },
-            "phone_number": "12345678",
         }
 
         # Setup Bob
@@ -249,8 +250,9 @@ class CreateApplicationTestCase(APITestCase):
 
         self.application_data = {
             "text": "Ønsker Webkom mest",
-            "applications": {"webkom": "Hohohohohohohohohohooho webbis"},
             "phone_number": "12345678",
+            "header_fields_response": {},
+            "applications": {"webkom": "Hohohohohohohohohohooho webbis"},
         }
 
         # Apply then only with webkom, removing koskom
@@ -315,11 +317,12 @@ class ListApplicationsTestCase(APITestCase):
         # Sample application data
         self.application_data = {
             "text": "testtest",
+            "phone_number": "00000000",
+            "header_fields_response": {},
             "applications": {
                 "webkom": "Webkom application",
                 "bedkom": "Bedkom application",
             },
-            "phone_number": "00000000",
         }
 
     def unauthorized_user_cannot_see_other_applications(self):
@@ -369,8 +372,9 @@ class ListApplicationsTestCase(APITestCase):
         self.client.force_authenticate(user=self.pleb)
         application_data = {
             "text": "testtest",
-            "applications": {"webkom": "Webkom application"},
             "phone_number": "00000000",
+            "header_fields_response": {},
+            "applications": {"webkom": "Webkom application"},
         }
         self.client.post(
             reverse(

--- a/frontend/src/components/JsonFieldEditor/index.tsx
+++ b/frontend/src/components/JsonFieldEditor/index.tsx
@@ -8,9 +8,14 @@ import { FieldModel, PhoneInputModel, TextModel } from "src/utils/jsonFields";
 type Props = {
   sectionName: string;
   fields?: FieldModel[];
+  disabled?: boolean;
 };
 
-const JsonFieldEditor: React.FC<Props> = ({ sectionName, fields }) => {
+const JsonFieldEditor: React.FC<Props> = ({
+  sectionName,
+  fields,
+  disabled = false,
+}) => {
   const TextField = ({ field }: { field: TextModel }) => (
     <HelpText>
       <Icon name="information-circle-outline" />
@@ -25,6 +30,7 @@ const JsonFieldEditor: React.FC<Props> = ({ sectionName, fields }) => {
       title={field.title}
       label={field.label}
       placeholder={field.placeholder}
+      disabled={disabled}
     />
   );
 

--- a/frontend/src/containers/GroupApplication/Application.tsx
+++ b/frontend/src/containers/GroupApplication/Application.tsx
@@ -51,10 +51,10 @@ const Application: React.FC<ApplicationProps> = ({
         <ResponseLabel>{readmeIfy(responseLabel, true)}</ResponseLabel>
       )}
       <InputWrapper>
-        <FieldLabel htmlFor={group.name.toLowerCase()}>Søknadstekst</FieldLabel>
+        <FieldLabel htmlFor={name}>Søknadstekst</FieldLabel>
         <InputArea
           className="textarea"
-          name={"groups." + name}
+          name={name}
           id={name}
           onChange={onChange}
           onBlur={handleBlur}

--- a/frontend/src/query/mutations.ts
+++ b/frontend/src/query/mutations.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
-import { FieldModel } from "src/utils/jsonFields";
+import { FieldModel, InputResponseModel } from "src/utils/jsonFields";
 import { apiClient } from "../utils/callApi";
 
 // Admin mutations
@@ -146,6 +146,7 @@ export interface MutationApplication {
   text: string;
   phone_number: string;
   applications: Record<string, string>;
+  header_fields_response: InputResponseModel;
 }
 
 interface CreateApplicationProps {

--- a/frontend/src/routes/ApplicationForm/FormContainer.tsx
+++ b/frontend/src/routes/ApplicationForm/FormContainer.tsx
@@ -39,7 +39,7 @@ const FormContainer: React.FC<FormContainerProps> = ({
       <Field
         component={GroupApplication}
         group={group}
-        name={group.name.toLowerCase()}
+        name={"groups." + group.name.toLowerCase()}
         responseLabel={group.response_label}
         error={
           touched.groups &&

--- a/frontend/src/routes/ApplicationForm/index.tsx
+++ b/frontend/src/routes/ApplicationForm/index.tsx
@@ -13,14 +13,14 @@ import {
 } from "src/utils/draftHelper";
 import { Admission, Application, Group } from "src/types";
 import FormContainer from "./FormContainer";
-import { InputFieldModel } from "src/utils/jsonFields";
+import { InputFieldModel, InputResponseModel } from "src/utils/jsonFields";
 
 export type SelectedGroups = { [key: string]: boolean };
 
 export type FormValues = {
   priorityText: string;
   phoneNumber: string;
-  headerFields: { [fieldId: string]: string };
+  headerFields: InputResponseModel;
   groups: { [groupName: string]: string };
 };
 
@@ -61,7 +61,10 @@ const generateInitialValues: (
     .reduce(
       (obj, field) => ({
         ...obj,
-        [field.id]: "",
+        [field.id]:
+          (myApplication?.header_fields_response &&
+            myApplication?.header_fields_response[field.id]) ??
+          "",
       }),
       {}
     );
@@ -150,6 +153,7 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({
       text: values.priorityText,
       applications: {},
       phone_number: values.phoneNumber,
+      header_fields_response: values.headerFields,
     };
     Object.keys(values.groups)
       .filter((group) => selectedGroups[group])

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -34,6 +34,7 @@ import {
   Title,
 } from "src/routes/ApplicationForm/FormStructureStyle";
 import { clearAllDrafts } from "src/utils/draftHelper";
+import JsonFieldEditor from "src/components/JsonFieldEditor";
 
 interface FormStructureProps {
   toggleIsEditing: () => void;
@@ -148,6 +149,11 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
             component={PhoneNumberField}
             disabled={true}
           />
+          <JsonFieldEditor
+            sectionName="headerFields"
+            fields={admission?.header_fields}
+            disabled={true}
+          />
         </GeneralInfoSection>
         <SeparatorLine />
         <GroupsSection>
@@ -180,7 +186,7 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
                   <Field
                     component={Application}
                     group={group}
-                    name={group.name.toLowerCase()}
+                    name={"groups." + group.name.toLowerCase()}
                     responseLabel={group.response_label}
                     key={group.pk}
                     disabled={true}

--- a/frontend/src/routes/ReceiptForm/index.tsx
+++ b/frontend/src/routes/ReceiptForm/index.tsx
@@ -4,6 +4,7 @@ import { useMyApplication } from "src/query/hooks";
 
 import FormStructure from "./FormStructure";
 import { useParams } from "react-router-dom";
+import { FormValues } from "../ApplicationForm";
 
 interface FormProps {
   toggleIsEditing: () => void;
@@ -19,6 +20,10 @@ const ApplicationForm: React.FC<FormProps> = ({ toggleIsEditing }) => {
 
   if (isFetching) return <p>Loading</p>;
 
+  if (!myApplication) {
+    return <p>Feil: klarte ikke hente søknaden din.</p>;
+  }
+
   const { phone_number, text, group_applications } = myApplication ?? {};
 
   const groupApplications = group_applications?.reduce(
@@ -29,14 +34,18 @@ const ApplicationForm: React.FC<FormProps> = ({ toggleIsEditing }) => {
     {}
   );
 
-  const initialValues = {
-    priorityText: text,
+  const initialValues: FormValues = {
+    priorityText: text ?? "",
     phoneNumber: phone_number,
-    ...groupApplications,
+    headerFields: myApplication?.header_fields_response,
+    groups: groupApplications,
   };
 
   return (
-    <Formik initialValues={initialValues} onSubmit={() => undefined}>
+    <Formik<FormValues>
+      initialValues={initialValues}
+      onSubmit={() => undefined}
+    >
       <FormStructure toggleIsEditing={toggleIsEditing} />
     </Formik>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-import { FieldModel } from "src/utils/jsonFields";
+import { FieldModel, InputResponseModel } from "src/utils/jsonFields";
 
 export interface Group {
   pk: number;
@@ -25,11 +25,12 @@ export interface GroupApplication {
 export interface Application {
   pk: number;
   user: User;
-  applied_within_deadline: boolean;
   created_at: string;
   updated_at: string;
+  applied_within_deadline: boolean;
   text?: string;
   phone_number: string;
+  header_fields_response: InputResponseModel;
   group_applications: GroupApplication[];
 }
 

--- a/frontend/src/utils/jsonFields.ts
+++ b/frontend/src/utils/jsonFields.ts
@@ -27,21 +27,4 @@ export type InputFieldModel =
 
 export type FieldModel = TextModel | InputFieldModel;
 
-type BaseInputResponseModel = {
-  input_id: string;
-  value: string;
-};
-
-export type TextInputResponseModel = BaseInputResponseModel;
-
-export type TextAreaResponseModel = BaseInputResponseModel;
-
-export type NumberInputResponseModel = BaseInputResponseModel;
-
-export type PhoneInputResponseModel = BaseInputResponseModel;
-
-export type InputResponseModel =
-  | TextInputResponseModel
-  | TextAreaResponseModel
-  | NumberInputResponseModel
-  | PhoneInputResponseModel;
+export type InputResponseModel = { [input_id: string]: string };


### PR DESCRIPTION
Answers are now validated, stored and displayed both after the application has been submitted and when it is being edited.

Upcoming;
* The values are still not visible from the admin-panel or when the csv with application-data is downloaded

Responses are stored in the following format;
```json
{"question_id (uuid)": "value"}
```
And validated reading the values set for the corresponding question (such as `required`, and on the basis of `type`);
```
{
    "id": "question_id (uuid)",
    "title": "Telefonnummer",
    "label": "Vi bruker dette dersom du ikke svarer på det andre",
    "placeholder": "12345678",
    "required": true,
    "type": "phoneinput"
}
```

Resolves ABA-733