### PR TITLE
Add GUI to customize csv-export options

### DIFF
--- a/frontend/src/routes/AdmissionAdmin/ViewApplications.tsx
+++ b/frontend/src/routes/AdmissionAdmin/ViewApplications.tsx
@@ -9,22 +9,17 @@ import { useAdmission, useApplications } from "src/query/hooks";
 import { useParams } from "react-router-dom";
 
 import AdmissionsContainer from "src/containers/AdmissionsContainer";
-import { CsvData } from "./EditGroup";
 import { Application } from "src/types";
 import {
-  CSVExport,
   Statistics,
   StatisticsName,
   StatisticsWrapper,
 } from "./components/StyledElements";
 import djangoData from "src/utils/djangoData";
 import { InputFieldModel } from "src/utils/jsonFields";
-
-type CompleteCsvData = {
-  priorityText: string;
-  group: string;
-  groupApplicationText: string;
-} & Omit<CsvData, "applicationText">;
+import CSVExportHandler, {
+  CompleteCsvData,
+} from "./components/CSVExportHandler";
 
 const ViewApplications = () => {
   const { admissionSlug } = useParams();
@@ -188,14 +183,7 @@ const ViewApplications = () => {
               ))}
           </Statistics>
         </Statistics>
-        <CSVExport
-          data={csvData}
-          headers={csvHeaders}
-          filename={"applications.csv"}
-          target="_blank"
-        >
-          Eksporter som csv
-        </CSVExport>
+        <CSVExportHandler csvData={csvData} csvHeaders={csvHeaders} />
         <AdmissionsContainer
           admission={admission}
           applications={filteredApplications}

--- a/frontend/src/routes/AdmissionAdmin/components/CSVExportHandler.tsx
+++ b/frontend/src/routes/AdmissionAdmin/components/CSVExportHandler.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { CsvData } from "../EditGroup";
+import { CSVExport } from "./StyledElements";
+
+export type CompleteCsvData = {
+  priorityText: string;
+  group: string;
+  groupApplicationText: string;
+} & Omit<CsvData, "applicationText">;
+
+const csvFormats = [
+  { name: "Google Sheets", separator: ",", enclosingCharacter: '"' },
+  { name: "Excel (norsk)", separator: ";", enclosingCharacter: '"' },
+];
+
+type Props = {
+  csvData: CompleteCsvData[];
+  csvHeaders: { label: string; key: string }[];
+};
+
+const CSVExportHandler: React.FC<Props> = ({ csvData, csvHeaders }) => {
+  const [csvFormat, setCsvFormat] = useState(csvFormats[0]);
+
+  return (
+    <Wrapper>
+      <FormatSelector>
+        <label htmlFor={"csv-selector"}>Velg CSV-format</label>
+        <select
+          id={"csv-selector"}
+          onChange={(event) =>
+            setCsvFormat(
+              csvFormats.find(
+                (csvFormat) => csvFormat.name === event.target.value
+              ) ?? csvFormats[0]
+            )
+          }
+        >
+          {csvFormats.map((csvFormat) => (
+            <option key={csvFormat.name} value={csvFormat.name}>
+              {csvFormat.name}
+            </option>
+          ))}
+        </select>
+      </FormatSelector>
+      <CSVExport
+        data={csvData}
+        headers={csvHeaders}
+        filename={"applications.csv"}
+        target="_blank"
+        separator={csvFormat.separator}
+        enclosingCharacter={csvFormat.enclosingCharacter}
+      >
+        Eksporter som csv
+      </CSVExport>
+    </Wrapper>
+  );
+};
+
+export default CSVExportHandler;
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const FormatSelector = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-basis: 200px;
+  padding: 0 10px;
+  border-top: 5px solid rgb(192, 57, 43);
+  border-bottom: 1px solid rgb(192, 57, 43);
+`;


### PR DESCRIPTION
It's a highly annoying experience to try to get Excel to read csv files in another delimeter than it expects, so it was about time to allow users to select what they need the export for

## Before
<img width="965" alt="image" src="https://github.com/webkom/admissions/assets/13599770/869d744e-09ba-4f02-be63-bbad35bd6fcf">


## After
<img width="966" alt="image" src="https://github.com/webkom/admissions/assets/13599770/48e44a77-7a82-4dbd-85a4-d4c927d12964">

<img width="965" alt="image" src="https://github.com/webkom/admissions/assets/13599770/82f5bdd4-e2d3-473b-b3f1-c39f0a28bff8">


Resolves ABA-735
Resolves #878 