### PR TITLE
Move create-admission page to /admin/create

### DIFF
--- a/frontend/src/routes/LandingPage/LandingPageNoAdmission.tsx
+++ b/frontend/src/routes/LandingPage/LandingPageNoAdmission.tsx
@@ -13,15 +13,21 @@ const LandingPageNoAdmission = () => {
       <InfoBox>
         <DecorativeLine vertical />
         <p>
-          Komiteeopptak skjer vanligvis i september etter semesterstart. Følg
-          med på{" "}
-          <a href="https://abakus.no" target="_blank" rel="noopener noreferrer">
+          Opptak til{" "}
+          <a href="https://abakus.no/pages/grupper/104-revyen">revyen</a> og{" "}
+          <a href="https://abakus.no/pages/komiteer/4">komiteene</a> skjer
+          vanligvis i september etter semesterstart.{" "}
+          <a href="https://abakus.no/pages/komiteer/5">backup</a> har vanligvis
+          opptak i februar.
+          <br />
+          <br />
+          Følg med på{" "}
+          <a href="https://abakus.no" rel="noopener noreferrer">
             abakus.no
           </a>{" "}
           eller på{" "}
           <a
             href="https://www.facebook.com/AbakusNTNU/"
-            target="_blank"
             rel="noopener noreferrer"
           >
             vår facebook side

--- a/frontend/src/routes/ManageAdmissions/components/NavBar.tsx
+++ b/frontend/src/routes/ManageAdmissions/components/NavBar.tsx
@@ -21,7 +21,12 @@ const NavBar: React.FC<Props> = ({ admissions }) => {
         <p>Du har ikke redigeringstilgang til noen opptak.</p>
       )}
       <CreateNewWrapper>
-        <LegoButton buttonStyle="primary" to="/admin/" icon="add" size="small">
+        <LegoButton
+          buttonStyle="primary"
+          to="/admin/create"
+          icon="add"
+          size="small"
+        >
           Lag nytt
         </LegoButton>
       </CreateNewWrapper>

--- a/frontend/src/routes/ManageAdmissions/index.tsx
+++ b/frontend/src/routes/ManageAdmissions/index.tsx
@@ -30,7 +30,10 @@ const ManageAdmissions: React.FC = () => {
           </LeftSide>
           <RightSide>
             <Routes>
-              <Route path="" element={<CreateAdmission key="newAdmission" />} />
+              <Route
+                path="/create"
+                element={<CreateAdmission key="newAdmission" />}
+              />
               <Route
                 path=":admissionSlug"
                 element={<CreateAdmission key="editAdmission" />}


### PR DESCRIPTION
Bugged me that it wasn't that clear when you entered /admin whether you were creating or editing an admission, so now the page is blank except for the sidebar when you enter /admin, and you can either go to /admin/<slug> or /admin/create.

Also made a 'lil update on the blank page as it was kinda outdated.

## Before
<img width="481" alt="image" src="https://github.com/webkom/admissions/assets/13599770/f7e440c9-6b8c-4c27-92e3-73ff46926bb9">


## After
<img width="496" alt="image" src="https://github.com/webkom/admissions/assets/13599770/7b5a4128-fa60-4789-93ae-803471984ff5">
