### PR TITLE
Rename admin endpoint to manage

### DIFF
--- a/admissions/admissions/tests/test_manage_admission_delete.py
+++ b/admissions/admissions/tests/test_manage_admission_delete.py
@@ -42,7 +42,7 @@ class DeleteAdmissionAuthorizationTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -60,7 +60,7 @@ class DeleteAdmissionAuthorizationTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -82,7 +82,7 @@ class DeleteAdmissionAuthorizationTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -96,7 +96,7 @@ class DeleteAdmissionAuthorizationTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -111,7 +111,7 @@ class DeleteAdmissionAuthorizationTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -137,7 +137,7 @@ class DeleteAdmissionValidityTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -196,7 +196,7 @@ class DeleteAdmissionCompleteTestCase(APITestCase):
         )
 
         res = self.client.delete(
-            reverse("admin-admission-detail", kwargs={"slug": self.admission.slug})
+            reverse("manage-admission-detail", kwargs={"slug": self.admission.slug})
         )
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/admissions/urls.py
+++ b/admissions/urls.py
@@ -29,8 +29,8 @@ from admissions.admissions.views import (
     PublicApplicationViewSet,
 )
 
-adminRouter = routers.DefaultRouter()
-adminRouter.register(r"admission", ManageAdmissionViewSet, "admin-admission")
+manageRouter = routers.DefaultRouter()
+manageRouter.register(r"admission", ManageAdmissionViewSet, "manage-admission")
 
 router = routers.DefaultRouter()
 router.register(r"admission", AdmissionViewSet)
@@ -45,7 +45,7 @@ router.register(
 router.register(r"group", GroupViewSet)
 urlpatterns = [
     re_path(r"logout/$", auth_views.LogoutView.as_view(), name="logout"),
-    path("api/admin/", include(adminRouter.urls)),
+    path("api/manage/", include(manageRouter.urls)),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("api/", include(router.urls)),
     re_path("", include("social_django.urls", namespace="social")),

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -58,7 +58,7 @@ const AppRoutes = () =>
   useRoutes([
     { path: "/", element: <LandingPage /> },
     {
-      path: "/admin/*",
+      path: "/manage/*",
       element: (
         <RequireAuth
           auth={

--- a/frontend/src/query/hooks.ts
+++ b/frontend/src/query/hooks.ts
@@ -38,13 +38,15 @@ export const useAdminApplications = (admissionSlug: string) => {
 
 // Manage hooks
 
-export const useAdminAdmissions = () => {
-  return useQuery<Admission[], AxiosError>({ queryKey: ["/admin/admission/"] });
+export const useManageAdmissions = () => {
+  return useQuery<Admission[], AxiosError>({
+    queryKey: ["/manage/admission/"],
+  });
 };
 
-export const useAdminAdmission = (slug: string, enabled = true) => {
+export const useManageAdmission = (slug: string, enabled = true) => {
   return useQuery<Admission, AxiosError>({
-    queryKey: [`/admin/admission/${slug}/`],
+    queryKey: [`/manage/admission/${slug}/`],
     enabled,
   });
 };

--- a/frontend/src/query/mutations.ts
+++ b/frontend/src/query/mutations.ts
@@ -109,7 +109,7 @@ export interface AdmissionMutationResponse extends MutationAdmission {
   created_by: number;
 }
 
-export const useAdminCreateAdmission = () => {
+export const useManageCreateAdmission = () => {
   const queryClient = useQueryClient();
   return useMutation<
     AdmissionMutationResponse,
@@ -117,9 +117,9 @@ export const useAdminCreateAdmission = () => {
     CreateAdmissionProps
   >({
     mutationFn: async ({ admission }) =>
-      (await apiClient.post("/admin/admission/", admission)).data,
+      (await apiClient.post("/manage/admission/", admission)).data,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [`/admin/admission/`] });
+      queryClient.invalidateQueries({ queryKey: [`/manage/admission/`] });
     },
   });
 };
@@ -128,7 +128,7 @@ interface UpdateAdmissionProps extends CreateAdmissionProps {
   slug: string;
 }
 
-export const useAdminUpdateAdmission = () => {
+export const useManageUpdateAdmission = () => {
   const queryClient = useQueryClient();
   return useMutation<
     AdmissionMutationResponse,
@@ -136,11 +136,11 @@ export const useAdminUpdateAdmission = () => {
     UpdateAdmissionProps
   >({
     mutationFn: async ({ slug, admission }) =>
-      (await apiClient.patch(`/admin/admission/${slug}/`, admission)).data,
+      (await apiClient.patch(`/manage/admission/${slug}/`, admission)).data,
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: [`/admin/admission/`] });
+      queryClient.invalidateQueries({ queryKey: [`/manage/admission/`] });
       queryClient.invalidateQueries({
-        queryKey: [`/admin/admission/${variables.slug}/`],
+        queryKey: [`/manage/admission/${variables.slug}/`],
       });
     },
   });
@@ -150,7 +150,7 @@ interface DeleteAdmissionProps {
   slug: string;
 }
 
-export const useAdminDeleteAdmission = () => {
+export const useManageDeleteAdmission = () => {
   const queryClient = useQueryClient();
   return useMutation<
     AdmissionMutationResponse,
@@ -158,11 +158,11 @@ export const useAdminDeleteAdmission = () => {
     DeleteAdmissionProps
   >({
     mutationFn: async ({ slug }) =>
-      (await apiClient.delete(`/admin/admission/${slug}/`)).data,
+      (await apiClient.delete(`/manage/admission/${slug}/`)).data,
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: [`/admin/admission/`] });
+      queryClient.invalidateQueries({ queryKey: [`/manage/admission/`] });
       queryClient.invalidateQueries({
-        queryKey: [`/admin/admission/${variables.slug}/`],
+        queryKey: [`/manage/admission/${variables.slug}/`],
       });
     },
   });

--- a/frontend/src/routes/LandingPage/LandingPageSkeleton.tsx
+++ b/frontend/src/routes/LandingPage/LandingPageSkeleton.tsx
@@ -17,7 +17,7 @@ const LandingPageSkeleton: React.FC<PropsWithChildren> = ({ children }) => {
       {(djangoData.user.is_staff || djangoData.user.is_member_of_webkom) && (
         <LegoButtonWrapper>
           <LegoButton
-            to={`/admin/`}
+            to={`/manage/`}
             icon="arrow-forward"
             iconPrefix="ios"
             buttonStyle="secondary"

--- a/frontend/src/routes/ManageAdmissions/CreateAdmission.tsx
+++ b/frontend/src/routes/ManageAdmissions/CreateAdmission.tsx
@@ -5,13 +5,13 @@ import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import ConfirmModal from "src/components/ConfirmModal";
 import LegoButton from "src/components/LegoButton";
-import { useAdminAdmission } from "src/query/hooks";
+import { useManageAdmission } from "src/query/hooks";
 import {
   AdmissionMutationResponse,
   MutationAdmission,
-  useAdminCreateAdmission,
-  useAdminDeleteAdmission,
-  useAdminUpdateAdmission,
+  useManageCreateAdmission,
+  useManageDeleteAdmission,
+  useManageUpdateAdmission,
 } from "src/query/mutations";
 import { toggleFromArray } from "src/utils/methods";
 import styled from "styled-components";
@@ -39,11 +39,11 @@ const CreateAdmission: React.FC = () => {
     data: admission,
     isLoading,
     error,
-  } = useAdminAdmission(admissionSlug ?? "", admissionSlug !== undefined);
+  } = useManageAdmission(admissionSlug ?? "", admissionSlug !== undefined);
 
-  const createAdmission = useAdminCreateAdmission();
-  const updateAdmission = useAdminUpdateAdmission();
-  const deleteAdmission = useAdminDeleteAdmission();
+  const createAdmission = useManageCreateAdmission();
+  const updateAdmission = useManageUpdateAdmission();
+  const deleteAdmission = useManageDeleteAdmission();
 
   const [returnedData, setReturnedData] = useState<ReturnedData>();
 
@@ -78,7 +78,7 @@ const CreateAdmission: React.FC = () => {
       const onSuccess = (data: AdmissionMutationResponse) => {
         setReturnedData({ type: "success", message: "Opptaket er lagret!" });
         if (data?.slug) {
-          navigate("/admin/" + data.slug);
+          navigate("/manage/" + data.slug);
         }
       };
       const onError = (error: AxiosError) => {
@@ -113,7 +113,14 @@ const CreateAdmission: React.FC = () => {
 
   const handleDeleteAdmission = () => {
     if (!admission) return;
-    deleteAdmission.mutate({ slug: admission.slug });
+    deleteAdmission.mutate(
+      { slug: admission.slug },
+      {
+        onSuccess: () => {
+          navigate("/manage/");
+        },
+      },
+    );
   };
 
   useEffect(() => {

--- a/frontend/src/routes/ManageAdmissions/components/NavBar.tsx
+++ b/frontend/src/routes/ManageAdmissions/components/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBar: React.FC<Props> = ({ admissions }) => {
       {admissions?.map((admission) => (
         <NavLink
           key={admission.pk + admission.title}
-          to={"/admin/" + admission.slug}
+          to={"/manage/" + admission.slug}
         >
           {admission.title}
         </NavLink>
@@ -26,7 +26,7 @@ const NavBar: React.FC<Props> = ({ admissions }) => {
       <CreateNewWrapper>
         <LegoButton
           buttonStyle="primary"
-          to="/admin/create"
+          to="/manage/create"
           icon="add"
           size="small"
         >

--- a/frontend/src/routes/ManageAdmissions/index.tsx
+++ b/frontend/src/routes/ManageAdmissions/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { Link, Route, Routes } from "react-router-dom";
-import { useAdminAdmissions } from "src/query/hooks";
+import { useManageAdmissions } from "src/query/hooks";
 import { media } from "src/styles/mediaQueries";
 import LoadingBall from "src/components/LoadingBall";
 import NavBar from "./components/NavBar";
@@ -9,7 +9,7 @@ import CreateAdmission from "./CreateAdmission";
 import Icon from "src/components/Icon";
 
 const ManageAdmissions: React.FC = () => {
-  const { data, isFetching, error } = useAdminAdmissions();
+  const { data, isFetching, error } = useManageAdmissions();
 
   if (error) {
     return <div>Error: {error.message}</div>;


### PR DESCRIPTION
Enforce verbal separation of the two functions, where managers create and delete admissions whereas admins view and handle applications