### PR TITLE
Apply proper sorting to admissions

### DIFF
--- a/admissions/admissions/views.py
+++ b/admissions/admissions/views.py
@@ -89,6 +89,22 @@ class AdmissionViewSet(viewsets.ModelViewSet):
 
         return AdmissionListPublicSerializer
 
+    def list(self, request, *args, **kwargs):
+        serializer = self.get_serializer(self.get_queryset(), many=True)
+
+        # Sorting after the data has been fetched to be able to use the models properties
+        serializer_data = sorted(
+            serializer.data,
+            key=lambda admission: (
+                -admission["is_open"],
+                -admission["is_appliable"],
+                admission["is_closed"],
+                admission["public_deadline"],
+            ),
+        )
+
+        return Response(serializer_data)
+
 
 class GroupViewSet(viewsets.ModelViewSet):
     queryset = Group.objects.all()


### PR DESCRIPTION
The sorting has been illogical ever since multiple admissions were implemented.

This should resolve that, applying the following sorting;

1. Open admissions
    1. Public deadline has not yet passed
    2. Public deadline has passed
3. Not open admissions
    1. Will open some time in the future
    2. Closed admissions

Within these groupings they are all sorted based on their public_deadline

Resolves ABA-569