### PR TITLE
Separate admission endpoints

### DIFF
--- a/admissions/oauth.py
+++ b/admissions/oauth.py
@@ -19,6 +19,8 @@ class LegoOAuth2(BaseOAuth2):
     ]
 
     LEGO_GROUP_NAMES = [
+        # Committee admissions
+        "Abakus-leder",
         "Arrkom",
         "Bankkom",
         "Bedkom",
@@ -28,6 +30,19 @@ class LegoOAuth2(BaseOAuth2):
         "readme",
         "PR",
         "Webkom",
+        # Revue admissions
+        "RevyStyret",
+        "Band",
+        "Dans",
+        "Kostyme",
+        "Manus",
+        "PR-revy",
+        "Scene",
+        "Skuespill",
+        "Sosial",
+        "Teknikk",
+        # backup admissions
+        "backup",
     ]
 
     def get_scope(self):

--- a/admissions/urls.py
+++ b/admissions/urls.py
@@ -21,34 +21,42 @@ from django.urls import include, path, re_path
 from rest_framework import routers
 
 from admissions.admissions.views import (
+    AdminAdmissionViewSet,
     AdminApplicationViewSet,
-    AdmissionViewSet,
+    AdminGroupViewSet,
     AppView,
-    GroupViewSet,
     ManageAdmissionViewSet,
+    ManageGroupViewSet,
+    PublicAdmissionViewSet,
     PublicApplicationViewSet,
 )
 
-manageRouter = routers.DefaultRouter()
-manageRouter.register(r"admission", ManageAdmissionViewSet, "manage-admission")
-
-router = routers.DefaultRouter()
-router.register(r"admission", AdmissionViewSet)
-router.register(
+publicRouter = routers.DefaultRouter()
+publicRouter.register(r"admission", PublicAdmissionViewSet)
+publicRouter.register(
     r"admission/(?P<admission_slug>[-\w]+)/application", PublicApplicationViewSet
 )
-router.register(
-    r"admission/(?P<admission_slug>[-\w]+)/admin/application",
+
+adminRouter = routers.DefaultRouter()
+adminRouter.register(r"admission", AdminAdmissionViewSet, "admin-admission")
+adminRouter.register(
+    r"admission/(?P<admission_slug>[-\w]+)/application",
     AdminApplicationViewSet,
     "admin-userapplication",
 )
-router.register(r"group", GroupViewSet)
+adminRouter.register(r"group", AdminGroupViewSet, "admin-group")
+
+manageRouter = routers.DefaultRouter()
+manageRouter.register(r"admission", ManageAdmissionViewSet, "manage-admission")
+manageRouter.register(r"group", ManageGroupViewSet, "manage-group")
+
 
 urlpatterns = [
     re_path(r"logout/$", auth_views.LogoutView.as_view(), name="logout"),
+    path("api/admin/", include(adminRouter.urls)),
     path("api/manage/", include(manageRouter.urls)),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
-    path("api/", include(router.urls)),
+    path("api/", include(publicRouter.urls)),
     re_path("", include("social_django.urls", namespace="social")),
     re_path(r"^$", AppView.as_view(), name="home"),
 ]

--- a/frontend/src/query/hooks.ts
+++ b/frontend/src/query/hooks.ts
@@ -22,17 +22,29 @@ export const useMyApplication = (slug: string) => {
   });
 };
 
-export const useGroups = () => {
-  return useQuery<Group[], AxiosError>({
-    queryKey: ["/group/"],
+// Admin hooks
+
+export const useAdminAdmissions = () => {
+  return useQuery<Admission[], AxiosError>({
+    queryKey: ["/admin/admission/"],
   });
 };
 
-// Admin hooks
+export const useAdminAdmission = (slug: string) => {
+  return useQuery<Admission, AxiosError>({
+    queryKey: [`/admin/admission/${slug}/`],
+  });
+};
 
 export const useAdminApplications = (admissionSlug: string) => {
   return useQuery<Application[], AxiosError>({
-    queryKey: [`/admission/${admissionSlug}/admin/application/`],
+    queryKey: [`/admin/admission/${admissionSlug}/application/`],
+  });
+};
+
+export const useAdminGroups = () => {
+  return useQuery<Group[], AxiosError>({
+    queryKey: ["/admin/group/"],
   });
 };
 
@@ -48,5 +60,11 @@ export const useManageAdmission = (slug: string, enabled = true) => {
   return useQuery<Admission, AxiosError>({
     queryKey: [`/manage/admission/${slug}/`],
     enabled,
+  });
+};
+
+export const useManageGroups = () => {
+  return useQuery<Group[], AxiosError>({
+    queryKey: ["/manage/group/"],
   });
 };

--- a/frontend/src/query/mutations.ts
+++ b/frontend/src/query/mutations.ts
@@ -59,10 +59,10 @@ interface UpdateGroupErrorData {
   response_label: string[];
 }
 
-export const useUpdateGroupMutation = () =>
+export const useAdminUpdateGroupMutation = () =>
   useMutation<unknown, AxiosError<UpdateGroupErrorData>, UpdateGroupProps>({
     mutationFn: ({ groupPrimaryKey, updatedGroupData }) =>
-      apiClient.patch(`/group/${groupPrimaryKey}/`, updatedGroupData),
+      apiClient.patch(`/admin/group/${groupPrimaryKey}/`, updatedGroupData),
   });
 
 interface DeleteGroupApplicationProps {
@@ -75,14 +75,14 @@ export const useAdminDeleteApplicationMutation = (admissionSlug: string) => {
   return useMutation<unknown, AxiosError, DeleteGroupApplicationProps>({
     mutationFn: ({ applicationId, groupId }) =>
       apiClient.delete(
-        `/admission/${admissionSlug}/admin/application/${applicationId}/${
+        `/admin/admission/${admissionSlug}/application/${applicationId}/${
           groupId ? "?groupId=" + groupId : ""
         }`,
       ),
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [`/admission/${admissionSlug}/admin/application/`],
+        queryKey: [`/admin/admission/${admissionSlug}/application/`],
       });
     },
   });

--- a/frontend/src/routes/AdmissionAdmin/components/EditGroupForm.tsx
+++ b/frontend/src/routes/AdmissionAdmin/components/EditGroupForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Field, Form, Formik, FormikProps } from "formik";
 import * as Yup from "yup";
 
-import { useUpdateGroupMutation } from "src/query/mutations";
+import { useAdminUpdateGroupMutation } from "src/query/mutations";
 
 import TextAreaField from "src/components/TextAreaField";
 
@@ -41,7 +41,7 @@ const EditGroupForm: React.FC<EditGroupFormProps> = ({
   const [resetMutationTimeout, setResetMutationTimeout] =
     useState<NodeJS.Timeout>();
 
-  const updateGroupMutation = useUpdateGroupMutation();
+  const updateGroupMutation = useAdminUpdateGroupMutation();
 
   return (
     <Formik
@@ -92,7 +92,7 @@ const EditGroupForm: React.FC<EditGroupFormProps> = ({
 };
 
 type InnerFormProps = {
-  updateGroupMutation: ReturnType<typeof useUpdateGroupMutation>;
+  updateGroupMutation: ReturnType<typeof useAdminUpdateGroupMutation>;
 } & FormikProps<FormValues>;
 
 const InnerForm: React.FC<InnerFormProps> = ({

--- a/frontend/src/routes/LandingPage/LandingPageNoAdmission.tsx
+++ b/frontend/src/routes/LandingPage/LandingPageNoAdmission.tsx
@@ -35,7 +35,7 @@ const LandingPageNoAdmission = () => {
           for kunngjøringer!
         </p>
       </InfoBox>
-      <LinkButton to="https://abakus.no" secondary>
+      <LinkButton to="https://abakus.no" external secondary>
         Gå til abakus.no
       </LinkButton>
     </LandingPageSkeleton>

--- a/frontend/src/routes/ManageAdmissions/CreateAdmission.tsx
+++ b/frontend/src/routes/ManageAdmissions/CreateAdmission.tsx
@@ -16,6 +16,7 @@ import { toggleFromArray } from "src/utils/methods";
 import styled from "styled-components";
 import GroupSelector from "./components/GroupSelector";
 import { Button } from "@webkom/lego-bricks";
+import LoadingBall from "src/components/LoadingBall";
 
 interface ReturnedData {
   type: "error" | "success";
@@ -138,6 +139,10 @@ const CreateAdmission: React.FC = () => {
       });
     }
   }, [admission]);
+
+  if (!isNew && isLoading) {
+    return <LoadingBall />;
+  }
 
   if ((!isNew && !admission && !isLoading) || error?.response?.status === 404) {
     return <p>Fant ikke opptaket {admissionSlug}</p>;

--- a/frontend/src/routes/ManageAdmissions/components/GroupSelector.tsx
+++ b/frontend/src/routes/ManageAdmissions/components/GroupSelector.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useGroups } from "src/query/hooks";
+import { useManageGroups } from "src/query/hooks";
 import { Group } from "src/types";
 import styled from "styled-components";
 
@@ -12,7 +12,7 @@ const GroupSelector: React.FC<GroupSelectorProps> = ({
   value: selectedGroups,
   toggleGroup,
 }) => {
-  const { data: groups } = useGroups();
+  const { data: groups } = useManageGroups();
 
   const toggleSelectedGroup = (groupId: number) => {
     const group = groups?.find((group) => group.pk === groupId);


### PR DESCRIPTION
Some restructuring that I need for the next feature(:

Other minor changes
* Add all groups that are used for admissions
* Add missing prop to "Gå til abakus.no" button
* Add loading indicator to manage admission view