### PR TITLE
Update revy admissions email to be revysjef@abakus.no

### DIFF
--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -108,7 +108,7 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
         Du kan til enhver tid trekke søknaden din hvis du skulle ombestemme deg.
         Hvis det ikke fungerer å slette søknaden, send en mail til{" "}
         {isRevy ? (
-          <a href="mailto:revy@abakus.no">revy@abakus.no</a>
+          <a href="mailto:revysjef@abakus.no">revysjef@abakus.no</a>
         ) : (
           <a href="mailto:leder@abakus.no">leder@abakus.no</a>
         )}


### PR DESCRIPTION
Requested internally in revystyret meeting that emails go to revysjef@abakus.no instead of going to revy@abakus.no

