### PR TITLE
Add info for backup admission 2025

### DIFF
--- a/frontend/src/routes/ApplicationForm/FormStructure.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.tsx
@@ -14,6 +14,7 @@ import {
   GeneralInfoSection,
   GroupsSection,
   HelpText,
+  InfoText,
   NoChosenGroupsWrapper,
   NoChosenSubTitle,
   NoChosenTitle,
@@ -55,6 +56,7 @@ const FormStructure: React.FC<FormStructureProps> = ({
 }) => {
   const { data: myApplication } = useMyApplication(String(admission?.slug));
   const isRevy = admission?.slug === "revy";
+  const isBackup = admission?.slug === "backup";
   const isSingleGroupAdmission = admission?.groups.length === 1;
 
   return (
@@ -70,6 +72,64 @@ const FormStructure: React.FC<FormStructureProps> = ({
         )}
       </FormHeader>
       <Form>
+        {isBackup && (
+          <>
+            <SeparatorLine />
+            <GeneralInfoSection $columnCount={1}>
+              <SectionHeader>Informasjon</SectionHeader>
+              <InfoText>
+                Aller først - tusen takk for din interesse for å søke backup!
+                Lurer du på mer om oss kan du lese{" "}
+                <a
+                  href="https://abakus.no/articles/553-backup-har-opptak"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  denne artikkelen på abakus.no
+                </a>
+                .
+              </InfoText>
+              <InfoText>
+                Kriteriet for å søke er at du har interesse for Abakus og har
+                vært medlem i Abakus i minst 3 måneder. Absolutt alle kan søke
+                uavhengig om man har hatt tidligere verv eller ikke. For å søke
+                må du være i Trondheim det påfølgende høstsemesteret. Søkere som
+                blir værende hele det neste året vil bli prioritert, men
+                søknader fra de som kun er borte et halvt år vil likevel bli
+                vurdert.
+              </InfoText>
+              <InfoText>
+                Planen videre:
+                <ul>
+                  <li>07. mars kl. 23:59: Søknadsfrist</li>
+                  <li>27. februar - 07. mars: Kaffeprat*</li>
+                  <li>
+                    10/11. mars: Du får svar på om du kommer med eller ikke.{" "}
+                    <br />
+                    Kommer du ikke med i år anbefaler vi deg å søke til neste år
+                    igjen! Hold gjerne av ettermiddagen 12. mars i tilfelle du
+                    blir tatt opp.
+                  </li>
+                </ul>
+              </InfoText>
+              <InfoText>
+                *Dette er en lavterskelsamtale for at du skal bli bedre kjent
+                med oss og vi blir bedre kjent med deg. Dersom du er på
+                utveksling vil samtalene foregå over Zoom. Du vil bli kontaktet
+                av to backupere for å finne tid som passer:)
+              </InfoText>
+              <InfoText>
+                Vi håper du er motivert for å søke og ønsker deg lykke til i
+                prosessen. Dersom du har noen spørsmål eller innspill til
+                prosessen kan dette gjøres ved å sende en e-post til{" "}
+                <a href="mailto:backup-rekruttering@abakus.no">
+                  backup-rekruttering@abakus.no
+                </a>
+                .
+              </InfoText>
+            </GeneralInfoSection>
+          </>
+        )}
         <SeparatorLine />
         <GeneralInfoSection>
           <SectionHeader>Generelt</SectionHeader>
@@ -182,7 +242,9 @@ const FormStructure: React.FC<FormStructureProps> = ({
             <SubmitInfo>
               {isRevy
                 ? "Søknaden din kan kun ses av revystyret."
-                : "Din søknad til hver komité kan kun ses av den aktuelle komiteen og leder av Abakus."}{" "}
+                : isBackup
+                  ? "Søknaden din kan kun ses av medlemmer av backup."
+                  : "Din søknad til hver komité kan kun ses av den aktuelle komiteen og leder av Abakus."}{" "}
               All søknadsinformasjon slettes etter opptaket er gjennomført.
             </SubmitInfo>
             <SubmitInfo>Du kan når som helst trekke søknaden din.</SubmitInfo>

--- a/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
+++ b/frontend/src/routes/ApplicationForm/FormStructureStyle.tsx
@@ -67,7 +67,11 @@ export const CancelButtonContainer = styled.div`
 `;
 
 /* General info section, mobile number, priorities */
-export const GeneralInfoSection = styled.div`
+type InfoSectionProps = {
+  $columnCount?: number;
+};
+
+export const GeneralInfoSection = styled.div<InfoSectionProps>`
   display: flex;
   flex-wrap: wrap;
   gap: 1rem 2rem;
@@ -76,12 +80,11 @@ export const GeneralInfoSection = styled.div`
 
   > h2 {
     flex-basis: 100%;
-    margin-bottom: -1.5rem;
   }
 
   > span {
-    flex-basis: 50%;
-    margin-top: calc(1rem + 16px);
+    flex-basis: ${({ $columnCount = 2 }) =>
+      `calc(${(1 / $columnCount) * 100}% - ${($columnCount - 1) * 1}rem)`};
   }
 
   > div {
@@ -131,12 +134,24 @@ export const Text = styled.p`
   `}
 `;
 
-export const HelpText = styled.span`
-  color: rgba(57, 75, 89, 0.75);
+export const InfoText = styled.span`
   font-size: 0.9rem;
-  line-height: 1.2rem;
-  display: flex;
+  line-height: 1.5rem;
+
+  ${media.portrait`
+    font-size: 0.8rem;
+  `};
+
+  ul {
+    list-style-type: disc;
+    margin-left: 1rem;
+  }
+`;
+
+export const HelpText = styled(InfoText)`
+  color: rgba(57, 75, 89, 0.75);
   margin-left: calc(-2.6rem + 4px);
+  display: flex;
 
   i {
     color: var(--color-gray-3);
@@ -146,7 +161,6 @@ export const HelpText = styled.span`
 
   ${media.portrait`
     margin-left: 0;
-    font-size: 0.8rem;
 
     i {
       margin-right: 0.5rem;

--- a/frontend/src/routes/LandingPage/Admission.tsx
+++ b/frontend/src/routes/LandingPage/Admission.tsx
@@ -13,6 +13,7 @@ interface AdmissionProps {
 
 const Admission: React.FC<AdmissionProps> = ({ admission }) => {
   const isRevy = admission.slug === "revy";
+  const isBackup = admission.slug === "backup";
   const isSingleGroupAdmission = admission?.groups.length === 1;
 
   return (
@@ -111,6 +112,10 @@ const Admission: React.FC<AdmissionProps> = ({ admission }) => {
         Hvis det ikke fungerer å slette søknaden, send en mail til{" "}
         {isRevy ? (
           <a href="mailto:revysjef@abakus.no">revysjef@abakus.no</a>
+        ) : isBackup ? (
+          <a href="mailto:backup-rekruttering@abakus.no">
+            backup-rekruttering@abakus.no
+          </a>
         ) : (
           <a href="mailto:leder@abakus.no">leder@abakus.no</a>
         )}

--- a/frontend/src/routes/ReceiptForm/FormStructure.tsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.tsx
@@ -17,6 +17,7 @@ import {
   GeneralInfoSection,
   GroupsSection,
   HelpText,
+  InfoText,
   NoChosenGroupsWrapper,
   NoChosenSubTitle,
   NoChosenTitle,
@@ -54,6 +55,7 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
   const { data: admission } = useAdmission(admissionSlug ?? "");
   const { groups } = admission ?? {};
 
+  const isBackup = admission?.slug === "backup";
   const isSingleGroupAdmission = admission?.groups.length === 1;
 
   if (!admission) {
@@ -136,6 +138,46 @@ const FormStructure: React.FC<FormStructureProps> = ({ toggleIsEditing }) => {
           </EditActions>
         </EditWrapper>
       </RecieptInfo>
+
+      {isBackup && (
+        <>
+          <FormHeader>
+            <Title>Informasjon</Title>
+          </FormHeader>
+          <GeneralInfoSection $columnCount={1}>
+            <SeparatorLine />
+            <InfoText>
+              Tusen takk for din søknad! Dersom du har noen spørsmål eller
+              innspill til prosessen kan dette gjøres ved å sende en e-post til{" "}
+              <a href="mailto:backup-rekruttering@abakus.no">
+                backup-rekruttering@abakus.no
+              </a>
+              .
+            </InfoText>
+            <InfoText>
+              Planen videre:
+              <ul>
+                <li>07. mars kl. 23:59: Søknadsfrist</li>
+                <li>27. februar - 07. mars: Kaffeprat*</li>
+                <li>
+                  10/11. mars: Du får svar på om du kommer med eller ikke.{" "}
+                  <br />
+                  Kommer du ikke med i år anbefaler vi deg å søke til neste år
+                  igjen! Hold gjerne av ettermiddagen 12. mars i tilfelle du
+                  blir tatt opp.
+                </li>
+              </ul>
+            </InfoText>
+            <InfoText>
+              *Dette er en lavterskelsamtale for at du skal bli bedre kjent med
+              oss og vi blir bedre kjent med deg. Dersom du er på utveksling vil
+              samtalene foregå over Zoom. Du vil bli kontaktet av to backupere
+              for å finne tid som passer:)
+            </InfoText>
+          </GeneralInfoSection>
+          <SeparatorLine />
+        </>
+      )}
 
       <FormHeader>
         <Title>Innsendt data</Title>


### PR DESCRIPTION
Implemented in a way that would allow us to keep it in the codebase for later admissions instead of looking it up in old pull requests.

For a later point it might be possible to add this text through json fields - but for now this will have to do(: