### PR TITLE
Allow admin-groups to edit group data

### DIFF
--- a/admissions/admissions/permissions.py
+++ b/admissions/admissions/permissions.py
@@ -64,6 +64,15 @@ class GroupPermissions(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
+        # Allow a user to edit a group if it is the admin in an admission it is used
+        admissions = Admission.objects.filter(groups__pk__contains=obj.pk)
+        for admission in admissions:
+            for admin_group in admission.admin_groups.all():
+                if Membership.objects.filter(
+                    user=request.user.pk, group=admin_group.pk
+                ).exists():
+                    return True
+
         # Allow a user to edit a group if it is a leader or recruiter in that group
         return (
             Membership.objects.filter(user=request.user.pk, group=obj.pk)

--- a/frontend/src/routes/AdmissionAdmin/EditGroup.tsx
+++ b/frontend/src/routes/AdmissionAdmin/EditGroup.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { useAdmission } from "src/query/hooks";
-import djangoData from "src/utils/djangoData";
 import LoadingBall from "src/components/LoadingBall";
 import EditGroupForm from "./components/EditGroupForm";
 import { Wrapper, GroupLogo, GroupLogoWrapper } from "./components/styles";
@@ -19,7 +18,7 @@ export interface CsvData {
 }
 
 const EditGroup = () => {
-  const { admissionSlug } = useParams();
+  const { admissionSlug, groupId } = useParams();
 
   const {
     data: admission,
@@ -35,16 +34,15 @@ const EditGroup = () => {
   } else if (!groups) {
     return <div>Feil: klarte ikke laste inn grupper.</div>;
   } else {
-    const group = (groups ?? []).find(
-      (group) => group.name === djangoData.user.representative_of_group,
-    );
+    const group = (groups ?? []).find((group) => group.pk === groupId);
+    console.log(group);
     if (!group) return <div>Feil: Ugyldig gruppe</div>;
 
     return (
       <PageWrapper>
         <GroupLogoWrapper>
           <GroupLogo src={group.logo} />
-          <h2>{djangoData.user.representative_of_group}</h2>
+          <h2>{group.name}</h2>
         </GroupLogoWrapper>
 
         <Wrapper>

--- a/frontend/src/routes/AdmissionAdmin/components/NavBar.tsx
+++ b/frontend/src/routes/AdmissionAdmin/components/NavBar.tsx
@@ -10,10 +10,12 @@ interface Props {
 }
 
 const NavBar: React.FC<Props> = ({ admission }) => {
-  const representingGroup = useMemo(
+  const administrateGroups = useMemo(
     () =>
-      admission?.groups.find(
-        (group) => group.name === djangoData.user.representative_of_group,
+      admission?.groups.filter(
+        (group) =>
+          admission?.userdata.is_admin ||
+          group.name === djangoData.user.representative_of_group,
       ),
     [admission],
   );
@@ -27,10 +29,15 @@ const NavBar: React.FC<Props> = ({ admission }) => {
       <NavHeader>Administrer opptak</NavHeader>
       <NavLink to={"../admin/"}>Se søknader</NavLink>
       <NavHeader>Administrer grupper</NavHeader>
-      {representingGroup ? (
-        <NavLink to={"./groups/" + representingGroup.pk}>
-          {representingGroup.name}
-        </NavLink>
+      {administrateGroups?.length !== 0 ? (
+        administrateGroups?.map((administrateGroup) => (
+          <NavLink
+            key={administrateGroup.pk}
+            to={"./groups/" + administrateGroup.pk}
+          >
+            {administrateGroup.name}
+          </NavLink>
+        ))
       ) : (
         <p>
           Du har ikke tilgang til å redigere noen av gruppene i dette opptaket.


### PR DESCRIPTION
Allow members of admin_groups to edit group information for all groups

![image](https://github.com/user-attachments/assets/7e9fae33-f638-47e3-b3a7-f8a7ed9c5dfd)

Resolves ABA-1447